### PR TITLE
fix: Prevent panic in acp policy-ids query

### DIFF
--- a/utils/functional.go
+++ b/utils/functional.go
@@ -29,3 +29,17 @@ func MapFailableSlice[T any, U any](ts []T, mapper func(T) (U, error)) ([]U, err
 
 	return us, nil
 }
+
+// MapNullableSlice produces a new slice of elements from a slice of pointers, excluding 'nil' elements.
+func MapNullableSlice[T any, U any](ts []*T, mapper func(*T) U) []U {
+	us := make([]U, 0, len(ts))
+
+	for _, t := range ts {
+		if t != nil {
+			u := mapper(t)
+			us = append(us, u)
+		}
+	}
+
+	return us
+}

--- a/x/acp/keeper/query_policy_ids.go
+++ b/x/acp/keeper/query_policy_ids.go
@@ -5,8 +5,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	coretypes "github.com/sourcenetwork/acp_core/pkg/types"
-	"github.com/sourcenetwork/acp_core/pkg/utils"
 
+	"github.com/sourcenetwork/sourcehub/utils"
 	"github.com/sourcenetwork/sourcehub/x/acp/types"
 )
 
@@ -22,7 +22,8 @@ func (k Keeper) PolicyIds(goCtx context.Context, req *types.QueryPolicyIdsReques
 		return nil, err
 	}
 
+	// Use MapNullableSlice instead of MapSlice to filter out 'nil' policies.
 	return &types.QueryPolicyIdsResponse{
-		Ids: utils.MapSlice(resp.Policies, func(p *coretypes.Policy) string { return p.Id }),
+		Ids: utils.MapNullableSlice(resp.Policies, func(p *coretypes.Policy) string { return p.Id }),
 	}, nil
 }


### PR DESCRIPTION
## Description

This PR adds a fix to the `PolicyIds` keeper in the ACP module to prevent panics when querying policy-ids with no policies created.

## Tasks
- [x] Add `MapNullableSlice` function
- [x] Use `MapNullableSlice` instead of `MapSlice` in `PolicyIds` keeper
