### PR TITLE
fix: Improve custom inflation function

### DIFF
--- a/app/inflation.go
+++ b/app/inflation.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"cosmossdk.io/math"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
@@ -17,9 +16,9 @@ func ProvideInflationCalculationFn(
 	bankKeeper bankkeeper.Keeper,
 	stakingKeeper *stakingkeeper.Keeper,
 ) minttypes.InflationCalculationFn {
-	// Adjust bonded ratio based on the x/tier module developer stake so that it does not affect rewards
+	// Adjust bonded ratio based on the x/tier module developer stake so that it does not affect rewards.
 	return func(ctx context.Context, minter minttypes.Minter, params minttypes.Params, bondedRatio math.LegacyDec) math.LegacyDec {
-		devStake := tierKeeper.GetDeveloperStake(sdk.UnwrapSDKContext(ctx))
+		devStake := tierKeeper.GetTotalLockupsAmount(ctx)
 		totalSupply := bankKeeper.GetSupply(ctx, appparams.DefaultBondDenom).Amount
 
 		totalBonded, err := stakingKeeper.TotalBondedTokens(ctx)

--- a/app/inflation.go
+++ b/app/inflation.go
@@ -11,6 +11,22 @@ import (
 	tierkeeper "github.com/sourcenetwork/sourcehub/x/tier/keeper"
 )
 
+func CalculateInflation(
+	minter minttypes.Minter,
+	params minttypes.Params,
+	defaultBondedRatio math.LegacyDec,
+	devStake, totalBonded, totalSupply math.Int,
+) math.LegacyDec {
+	// Use default bonded raito for inflation calculation if one of the inputs is invalid.
+	if !totalSupply.IsPositive() || !totalBonded.IsPositive() || totalBonded.LT(devStake) || totalBonded.GT(totalSupply) {
+		return minter.NextInflationRate(params, defaultBondedRatio)
+	}
+
+	adjustedBonded := totalBonded.Sub(devStake)
+	adjustedBondedRatio := adjustedBonded.ToLegacyDec().QuoInt(totalSupply)
+	return minter.NextInflationRate(params, adjustedBondedRatio)
+}
+
 func ProvideInflationCalculationFn(
 	tierKeeper tierkeeper.Keeper,
 	bankKeeper bankkeeper.Keeper,
@@ -26,9 +42,6 @@ func ProvideInflationCalculationFn(
 			totalBonded = math.ZeroInt()
 		}
 
-		adjustedBonded := totalBonded.Sub(devStake)
-		adjustedBondedRatio := adjustedBonded.ToLegacyDec().QuoInt(totalSupply)
-
-		return minter.NextInflationRate(params, adjustedBondedRatio)
+		return CalculateInflation(minter, params, bondedRatio, devStake, totalBonded, totalSupply)
 	}
 }

--- a/app/inflation_test.go
+++ b/app/inflation_test.go
@@ -1,0 +1,96 @@
+package app
+
+import (
+	"testing"
+
+	"cosmossdk.io/math"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	appparams "github.com/sourcenetwork/sourcehub/app/params"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateInflation(t *testing.T) {
+	minter := minttypes.Minter{
+		Inflation: math.LegacyMustNewDecFromStr(appparams.InitialInflation),
+	}
+
+	params := minttypes.DefaultParams()
+	params.GoalBonded = math.LegacyMustNewDecFromStr(appparams.GoalBonded)
+	params.InflationMin = math.LegacyMustNewDecFromStr(appparams.InflationMin)
+	params.InflationMax = math.LegacyMustNewDecFromStr(appparams.InflationMax)
+	params.InflationRateChange = math.LegacyMustNewDecFromStr(appparams.InflationRateChange)
+
+	tests := []struct {
+		name                     string
+		devStake                 math.Int
+		totalBonded              math.Int
+		totalSupply              math.Int
+		expectDefaultBondedRatio bool
+	}{
+		{
+			name:                     "zero total supply",
+			devStake:                 math.NewInt(100),
+			totalBonded:              math.NewInt(1000),
+			totalSupply:              math.ZeroInt(),
+			expectDefaultBondedRatio: true,
+		},
+		{
+			name:                     "zero total bonded",
+			devStake:                 math.NewInt(100),
+			totalBonded:              math.ZeroInt(),
+			totalSupply:              math.NewInt(5000),
+			expectDefaultBondedRatio: true,
+		},
+		{
+			name:                     "totalBonded < devStake",
+			devStake:                 math.NewInt(1000),
+			totalBonded:              math.NewInt(500),
+			totalSupply:              math.NewInt(5000),
+			expectDefaultBondedRatio: true,
+		},
+		{
+			name:                     "totalBonded > totalSupply",
+			devStake:                 math.NewInt(1000),
+			totalBonded:              math.NewInt(6000),
+			totalSupply:              math.NewInt(5000),
+			expectDefaultBondedRatio: true,
+		},
+		{
+			name:                     "valid inputs (bondedRatio < GoalBonded)",
+			devStake:                 math.NewInt(100),
+			totalBonded:              math.NewInt(1000),
+			totalSupply:              math.NewInt(5000),
+			expectDefaultBondedRatio: false,
+		},
+		{
+			name:                     "valid inputs (bondedRatio > GoalBonded)",
+			devStake:                 math.NewInt(100),
+			totalBonded:              math.NewInt(4000),
+			totalSupply:              math.NewInt(5000),
+			expectDefaultBondedRatio: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var defaultBondedRatio, adjustedBondedRatio math.LegacyDec
+
+			if tc.totalSupply.IsZero() {
+				defaultBondedRatio = math.LegacyZeroDec()
+				adjustedBondedRatio = math.LegacyZeroDec()
+			} else {
+				defaultBondedRatio = tc.totalBonded.ToLegacyDec().QuoInt(tc.totalSupply)
+				adjustedBondedRatio = tc.totalBonded.Sub(tc.devStake).ToLegacyDec().QuoInt(tc.totalSupply)
+			}
+
+			expectedInflation := minter.NextInflationRate(params, adjustedBondedRatio)
+			if tc.expectDefaultBondedRatio {
+				expectedInflation = minter.NextInflationRate(params, defaultBondedRatio)
+			}
+
+			actualInflation := CalculateInflation(minter, params, defaultBondedRatio, tc.devStake, tc.totalBonded, tc.totalSupply)
+
+			require.Equal(t, expectedInflation, actualInflation, "Test failed: %s", tc.name)
+		})
+	}
+}

--- a/app/overrides/mint.go
+++ b/app/overrides/mint.go
@@ -24,6 +24,7 @@ func (MintModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 	genState.Params.InflationMin = math.LegacyMustNewDecFromStr(appparams.InflationMin)
 	genState.Params.InflationMax = math.LegacyMustNewDecFromStr(appparams.InflationMax)
 	genState.Params.InflationRateChange = math.LegacyMustNewDecFromStr(appparams.InflationRateChange)
+	genState.Minter.Inflation = math.LegacyMustNewDecFromStr(appparams.InitialInflation)
 
 	return cdc.MustMarshalJSON(genState)
 }

--- a/app/params/params.go
+++ b/app/params/params.go
@@ -23,4 +23,5 @@ const (
 	InflationMin        = "0.02"
 	InflationMax        = "0.15"
 	InflationRateChange = "0.13"
+	InitialInflation    = "0.13"
 )

--- a/x/tier/keeper/credit_test.go
+++ b/x/tier/keeper/credit_test.go
@@ -326,7 +326,8 @@ func TestProratedCredit(t *testing.T) {
 
 			k.removeLockup(ctx, delAddr, valAddr)
 			if tc.locked > 0 {
-				k.AddLockup(ctx, delAddr, valAddr, math.NewInt(tc.locked))
+				err = k.AddLockup(ctx, delAddr, valAddr, math.NewInt(tc.locked))
+				require.NoError(t, err)
 			}
 			got := k.proratedCredit(ctx, delAddr, math.NewInt(tc.locking))
 			require.Equal(t, tc.want, got.Int64())
@@ -499,7 +500,8 @@ func TestResetAllCredits(t *testing.T) {
 			for addrStr, lockupAmounts := range tt.lockups {
 				addr := sdk.MustAccAddressFromBech32(addrStr)
 				for _, amt := range lockupAmounts {
-					k.AddLockup(ctx, addr, valAddr, math.NewInt(amt))
+					err = k.AddLockup(ctx, addr, valAddr, math.NewInt(amt))
+					require.NoError(t, err)
 				}
 			}
 

--- a/x/tier/keeper/grpc_query_test.go
+++ b/x/tier/keeper/grpc_query_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 func TestParamsQuery(t *testing.T) {
-	keeper, ctx := keepertest.TierKeeper(t)
+	k, ctx := keepertest.TierKeeper(t)
 	params := types.DefaultParams()
-	require.NoError(t, keeper.SetParams(ctx, params))
+	require.NoError(t, k.SetParams(ctx, params))
 
-	querier := tierkeeper.NewQuerier(keeper)
+	querier := tierkeeper.NewQuerier(k)
 	response, err := querier.Params(ctx, &types.QueryParamsRequest{})
 
 	require.NoError(t, err)
@@ -26,11 +26,11 @@ func TestParamsQuery(t *testing.T) {
 }
 
 func TestParamsQuery_InvalidRequest(t *testing.T) {
-	keeper, ctx := keepertest.TierKeeper(t)
+	k, ctx := keepertest.TierKeeper(t)
 	params := types.DefaultParams()
-	require.NoError(t, keeper.SetParams(ctx, params))
+	require.NoError(t, k.SetParams(ctx, params))
 
-	querier := tierkeeper.NewQuerier(keeper)
+	querier := tierkeeper.NewQuerier(k)
 	response, err := querier.Params(ctx, nil)
 
 	require.Error(t, err)
@@ -39,7 +39,7 @@ func TestParamsQuery_InvalidRequest(t *testing.T) {
 }
 
 func TestLockupQuery(t *testing.T) {
-	keeper, ctx := keepertest.TierKeeper(t)
+	k, ctx := keepertest.TierKeeper(t)
 	amount := math.NewInt(1000)
 
 	delAddr, err := sdk.AccAddressFromBech32("source1wjj5v5rlf57kayyeskncpu4hwev25ty645p2et")
@@ -47,9 +47,10 @@ func TestLockupQuery(t *testing.T) {
 	valAddr, err := sdk.ValAddressFromBech32("sourcevaloper1cy0p47z24ejzvq55pu3lesxwf73xnrnd0pzkqm")
 	require.NoError(t, err)
 
-	keeper.AddLockup(ctx, delAddr, valAddr, amount)
+	err = k.AddLockup(ctx, delAddr, valAddr, amount)
+	require.NoError(t, err)
 
-	querier := tierkeeper.NewQuerier(keeper)
+	querier := tierkeeper.NewQuerier(k)
 	response, err := querier.Lockup(ctx, &types.LockupRequest{
 		DelegatorAddress: delAddr.String(),
 		ValidatorAddress: valAddr.String(),
@@ -66,11 +67,11 @@ func TestLockupQuery(t *testing.T) {
 }
 
 func TestLockupQuery_InvalidRequest(t *testing.T) {
-	keeper, ctx := keepertest.TierKeeper(t)
+	k, ctx := keepertest.TierKeeper(t)
 	params := types.DefaultParams()
-	require.NoError(t, keeper.SetParams(ctx, params))
+	require.NoError(t, k.SetParams(ctx, params))
 
-	querier := tierkeeper.NewQuerier(keeper)
+	querier := tierkeeper.NewQuerier(k)
 	response, err := querier.Lockup(ctx, nil)
 
 	require.Error(t, err)
@@ -79,7 +80,7 @@ func TestLockupQuery_InvalidRequest(t *testing.T) {
 }
 
 func TestLockupsQuery(t *testing.T) {
-	keeper, ctx := keepertest.TierKeeper(t)
+	k, ctx := keepertest.TierKeeper(t)
 	amount1 := math.NewInt(1000)
 	amount2 := math.NewInt(500)
 
@@ -88,10 +89,12 @@ func TestLockupsQuery(t *testing.T) {
 	valAddr, err := sdk.ValAddressFromBech32("sourcevaloper1cy0p47z24ejzvq55pu3lesxwf73xnrnd0pzkqm")
 	require.NoError(t, err)
 
-	keeper.AddLockup(ctx, delAddr, valAddr, amount1)
-	keeper.AddLockup(ctx, delAddr, valAddr, amount2)
+	err = k.AddLockup(ctx, delAddr, valAddr, amount1)
+	require.NoError(t, err)
+	err = k.AddLockup(ctx, delAddr, valAddr, amount2)
+	require.NoError(t, err)
 
-	querier := tierkeeper.NewQuerier(keeper)
+	querier := tierkeeper.NewQuerier(k)
 	response, err := querier.Lockups(ctx, &types.LockupsRequest{
 		DelegatorAddress: delAddr.String(),
 	})
@@ -102,11 +105,11 @@ func TestLockupsQuery(t *testing.T) {
 }
 
 func TestLockupsQuery_InvalidRequest(t *testing.T) {
-	keeper, ctx := keepertest.TierKeeper(t)
+	k, ctx := keepertest.TierKeeper(t)
 	params := types.DefaultParams()
-	require.NoError(t, keeper.SetParams(ctx, params))
+	require.NoError(t, k.SetParams(ctx, params))
 
-	querier := tierkeeper.NewQuerier(keeper)
+	querier := tierkeeper.NewQuerier(k)
 	response, err := querier.Lockups(ctx, nil)
 
 	require.Error(t, err)
@@ -115,8 +118,8 @@ func TestLockupsQuery_InvalidRequest(t *testing.T) {
 }
 
 func TestUnlockingLockupQuery(t *testing.T) {
-	keeper, ctx := keepertest.TierKeeper(t)
-	params := keeper.GetParams(ctx)
+	k, ctx := keepertest.TierKeeper(t)
+	params := k.GetParams(ctx)
 	epochDuration := *params.EpochDuration
 	amount := math.NewInt(1000)
 
@@ -130,9 +133,9 @@ func TestUnlockingLockupQuery(t *testing.T) {
 	completionTime := ctx.BlockTime().Add(epochDuration * time.Duration(params.UnlockingEpochs))
 	unlockTime := ctx.BlockTime().Add(epochDuration * time.Duration(params.UnlockingEpochs))
 
-	keeper.SetUnlockingLockup(ctx, delAddr, valAddr, int64(1), amount, completionTime, unlockTime)
+	k.SetUnlockingLockup(ctx, delAddr, valAddr, int64(1), amount, completionTime, unlockTime)
 
-	querier := tierkeeper.NewQuerier(keeper)
+	querier := tierkeeper.NewQuerier(k)
 	response, err := querier.UnlockingLockup(ctx, &types.UnlockingLockupRequest{
 		DelegatorAddress: delAddr.String(),
 		ValidatorAddress: valAddr.String(),
@@ -153,11 +156,11 @@ func TestUnlockingLockupQuery(t *testing.T) {
 }
 
 func TestUnlockingLockupQuery_InvalidRequest(t *testing.T) {
-	keeper, ctx := keepertest.TierKeeper(t)
+	k, ctx := keepertest.TierKeeper(t)
 	params := types.DefaultParams()
-	require.NoError(t, keeper.SetParams(ctx, params))
+	require.NoError(t, k.SetParams(ctx, params))
 
-	querier := tierkeeper.NewQuerier(keeper)
+	querier := tierkeeper.NewQuerier(k)
 	response, err := querier.UnlockingLockup(ctx, nil)
 
 	require.Error(t, err)
@@ -166,8 +169,8 @@ func TestUnlockingLockupQuery_InvalidRequest(t *testing.T) {
 }
 
 func TestUnlockingLockupsQuery(t *testing.T) {
-	keeper, ctx := keepertest.TierKeeper(t)
-	params := keeper.GetParams(ctx)
+	k, ctx := keepertest.TierKeeper(t)
+	params := k.GetParams(ctx)
 	epochDuration := *params.EpochDuration
 	amount1 := math.NewInt(1000)
 	amount2 := math.NewInt(500)
@@ -181,15 +184,15 @@ func TestUnlockingLockupsQuery(t *testing.T) {
 
 	completionTime1 := ctx.BlockTime().Add(time.Hour * 24 * 21)
 	unlockTime1 := ctx.BlockTime().Add(epochDuration * time.Duration(params.UnlockingEpochs))
-	keeper.SetUnlockingLockup(ctx, delAddr, valAddr, int64(1), amount1, completionTime1, unlockTime1)
+	k.SetUnlockingLockup(ctx, delAddr, valAddr, int64(1), amount1, completionTime1, unlockTime1)
 
 	ctx = ctx.WithBlockHeight(2).WithBlockTime(ctx.BlockTime().Add(time.Second))
 
 	completionTime2 := ctx.BlockTime().Add(time.Hour * 24 * 21)
 	unlockTime2 := ctx.BlockTime().Add(epochDuration * time.Duration(params.UnlockingEpochs))
-	keeper.SetUnlockingLockup(ctx, delAddr, valAddr, int64(2), amount2, completionTime2, unlockTime2)
+	k.SetUnlockingLockup(ctx, delAddr, valAddr, int64(2), amount2, completionTime2, unlockTime2)
 
-	querier := tierkeeper.NewQuerier(keeper)
+	querier := tierkeeper.NewQuerier(k)
 	response, err := querier.UnlockingLockups(ctx, &types.UnlockingLockupsRequest{
 		DelegatorAddress: delAddr.String(),
 	})
@@ -209,11 +212,11 @@ func TestUnlockingLockupsQuery(t *testing.T) {
 }
 
 func TestUnlockingLockupsQuery_InvalidRequest(t *testing.T) {
-	keeper, ctx := keepertest.TierKeeper(t)
+	k, ctx := keepertest.TierKeeper(t)
 	params := types.DefaultParams()
-	require.NoError(t, keeper.SetParams(ctx, params))
+	require.NoError(t, k.SetParams(ctx, params))
 
-	querier := tierkeeper.NewQuerier(keeper)
+	querier := tierkeeper.NewQuerier(k)
 	response, err := querier.UnlockingLockups(ctx, nil)
 
 	require.Error(t, err)

--- a/x/tier/keeper/keeper.go
+++ b/x/tier/keeper/keeper.go
@@ -173,7 +173,10 @@ func (k Keeper) Lock(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.Va
 	}
 
 	// Record the lockup
-	k.AddLockup(ctx, delAddr, valAddr, stake.Amount)
+	err = k.AddLockup(ctx, delAddr, valAddr, stake.Amount)
+	if err != nil {
+		return errorsmod.Wrap(err, "add lockup")
+	}
 
 	// Mint credits
 	creditAmt := k.proratedCredit(ctx, delAddr, amt)
@@ -266,7 +269,10 @@ func (k Keeper) Redelegate(ctx context.Context, delAddr sdk.AccAddress, srcValAd
 	}
 
 	// Add the lockup to the destination validator
-	k.AddLockup(ctx, delAddr, dstValAddr, amt)
+	err = k.AddLockup(ctx, delAddr, dstValAddr, amt)
+	if err != nil {
+		return time.Time{}, errorsmod.Wrap(err, "add lockup")
+	}
 
 	modAddr := authtypes.NewModuleAddress(types.ModuleName)
 	shares, err := k.stakingKeeper.ValidateUnbondAmount(ctx, modAddr, srcValAddr, amt)
@@ -369,7 +375,10 @@ func (k Keeper) CancelUnlocking(ctx context.Context, delAddr sdk.AccAddress, val
 	}
 
 	// Add the specified amt back to existing lockup
-	k.AddLockup(ctx, delAddr, valAddr, amt)
+	err = k.AddLockup(ctx, delAddr, valAddr, amt)
+	if err != nil {
+		return errorsmod.Wrap(err, "add lockup")
+	}
 
 	sdkCtx.EventManager().EmitEvent(
 		sdk.NewEvent(
@@ -382,17 +391,4 @@ func (k Keeper) CancelUnlocking(ctx context.Context, delAddr sdk.AccAddress, val
 	)
 
 	return nil
-}
-
-// GetDeveloperStake calculates and returns the total amount of all active lockups.
-func (k Keeper) GetDeveloperStake(ctx sdk.Context) math.Int {
-	totalDeveloperStake := math.ZeroInt()
-
-	lockupsCallback := func(delAddr sdk.AccAddress, valAddr sdk.ValAddress, lockup types.Lockup) {
-		totalDeveloperStake = totalDeveloperStake.Add(lockup.Amount)
-	}
-
-	k.MustIterateLockups(ctx, lockupsCallback)
-
-	return totalDeveloperStake
 }

--- a/x/tier/keeper/keeper_mock_test.go
+++ b/x/tier/keeper/keeper_mock_test.go
@@ -178,7 +178,9 @@ func (suite *KeeperTestSuite) TestUnlock() {
 	suite.tierKeeper.SetParams(suite.ctx, params)
 
 	// add a lockup and verify that it exists before trying to unlock
-	suite.tierKeeper.AddLockup(suite.ctx, delAddr, valAddr, amount)
+	err = suite.tierKeeper.AddLockup(suite.ctx, delAddr, valAddr, amount)
+	suite.Require().NoError(err)
+
 	lockedAmt := suite.tierKeeper.GetLockupAmount(suite.ctx, delAddr, valAddr)
 	suite.Require().Equal(amount, lockedAmt, "expected lockup amount to be set")
 
@@ -205,7 +207,8 @@ func (suite *KeeperTestSuite) TestRedelegate() {
 	suite.Require().NoError(err)
 
 	// add initial lockup to the source validator
-	suite.tierKeeper.AddLockup(suite.ctx, delAddr, srcValAddr, amount)
+	err = suite.tierKeeper.AddLockup(suite.ctx, delAddr, srcValAddr, amount)
+	suite.Require().NoError(err)
 
 	suite.stakingKeeper.EXPECT().
 		ValidateUnbondAmount(gomock.Any(), authtypes.NewModuleAddress(types.ModuleName), srcValAddr, amount).

--- a/x/tier/keeper/keeper_test.go
+++ b/x/tier/keeper/keeper_test.go
@@ -22,7 +22,7 @@ import (
 func initializeValidator(t *testing.T, k *stakingkeeper.Keeper, ctx sdk.Context, valAddr sdk.ValAddress, initialTokens math.Int) {
 	validator := testutil.CreateTestValidator(t, ctx, k, valAddr, cosmosed25519.GenPrivKey().PubKey(), initialTokens)
 	gotValidator, err := k.GetValidator(ctx, valAddr)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, validator.OperatorAddress, gotValidator.OperatorAddress)
 }
 

--- a/x/tier/keeper/lockup.go
+++ b/x/tier/keeper/lockup.go
@@ -165,12 +165,22 @@ func (k Keeper) removeUnlockingLockup(ctx context.Context, delAddr sdk.AccAddres
 }
 
 // AddLockup adds provided amt to the existing delAddr/valAddr lockup.
-func (k Keeper) AddLockup(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, amt math.Int) {
+func (k Keeper) AddLockup(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, amt math.Int) error {
+	total := k.GetTotalLockupsAmount(ctx)
+	total = total.Add(amt)
+	err := k.SetTotalLockupsAmount(ctx, total)
+	if err != nil {
+		return err
+	}
+
 	lockup := k.GetLockup(ctx, delAddr, valAddr)
 	if lockup != nil {
 		amt = amt.Add(lockup.Amount)
 	}
+
 	k.SetLockup(ctx, delAddr, valAddr, amt)
+
+	return nil
 }
 
 // SubtractLockup subtracts provided amt from the existing delAddr/valAddr lockup.
@@ -198,6 +208,17 @@ func (k Keeper) SubtractLockup(ctx context.Context, delAddr sdk.AccAddress, valA
 	}
 
 	k.SetLockup(ctx, delAddr, valAddr, newAmt)
+
+	total := k.GetTotalLockupsAmount(ctx)
+	newTotal, err := total.SafeSub(amt)
+	if err != nil {
+		return errorsmod.Wrapf(err, "subtract %s from total lockups amount %s", amt, lockup.Amount)
+	}
+
+	err = k.SetTotalLockupsAmount(ctx, newTotal)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -294,7 +315,7 @@ func (k Keeper) IterateUnlockingLockups(ctx context.Context,
 
 		err := cb(delAddr, valAddr, creationHeight, unlockingLockup)
 		if err != nil {
-			return errorsmod.Wrapf(err, "%s/%s/, amt: %s", delAddr, valAddr, unlockingLockup.Amount)
+			return errorsmod.Wrapf(err, "%s/%s/%d, amt: %s", delAddr, valAddr, creationHeight, unlockingLockup.Amount)
 		}
 	}
 
@@ -339,4 +360,33 @@ func (k Keeper) lockupStore(ctx context.Context, unlocking bool) prefix.Store {
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	storePrefix := types.KeyPrefix(unlocking)
 	return prefix.NewStore(storeAdapter, storePrefix)
+}
+
+// GetTotalLockupsAmount retrieves the total lockup amount from the store.
+func (k Keeper) GetTotalLockupsAmount(ctx context.Context) (total math.Int) {
+	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	bz := store.Get(types.TotalLockupsKey)
+	if bz == nil {
+		return math.ZeroInt()
+	}
+
+	err := total.Unmarshal(bz)
+	if err != nil {
+		return math.ZeroInt()
+	}
+
+	return total
+}
+
+// SetTotalLockupsAmount updates the total lockup amount in the store.
+func (k Keeper) SetTotalLockupsAmount(ctx context.Context, total math.Int) error {
+	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	bz, err := total.Marshal()
+	if err != nil {
+		return errorsmod.Wrapf(err, "marshal total lockups amount")
+	}
+
+	store.Set(types.TotalLockupsKey, bz)
+
+	return nil
 }

--- a/x/tier/keeper/lockup.go
+++ b/x/tier/keeper/lockup.go
@@ -185,6 +185,17 @@ func (k Keeper) AddLockup(ctx context.Context, delAddr sdk.AccAddress, valAddr s
 
 // SubtractLockup subtracts provided amt from the existing delAddr/valAddr lockup.
 func (k Keeper) SubtractLockup(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, amt math.Int) error {
+	total := k.GetTotalLockupsAmount(ctx)
+	newTotal, err := total.SafeSub(amt)
+	if err != nil {
+		return errorsmod.Wrapf(err, "subtract %s from total lockups amount %s", amt, total)
+	}
+
+	err = k.SetTotalLockupsAmount(ctx, newTotal)
+	if err != nil {
+		return err
+	}
+
 	lockup := k.GetLockup(ctx, delAddr, valAddr)
 	if lockup == nil {
 		return types.ErrNotFound.Wrap("subtract lockup")
@@ -208,17 +219,6 @@ func (k Keeper) SubtractLockup(ctx context.Context, delAddr sdk.AccAddress, valA
 	}
 
 	k.SetLockup(ctx, delAddr, valAddr, newAmt)
-
-	total := k.GetTotalLockupsAmount(ctx)
-	newTotal, err := total.SafeSub(amt)
-	if err != nil {
-		return errorsmod.Wrapf(err, "subtract %s from total lockups amount %s", amt, lockup.Amount)
-	}
-
-	err = k.SetTotalLockupsAmount(ctx, newTotal)
-	if err != nil {
-		return err
-	}
 
 	return nil
 }
@@ -372,6 +372,10 @@ func (k Keeper) GetTotalLockupsAmount(ctx context.Context) (total math.Int) {
 
 	err := total.Unmarshal(bz)
 	if err != nil {
+		return math.ZeroInt()
+	}
+
+	if total.IsNegative() {
 		return math.ZeroInt()
 	}
 

--- a/x/tier/keeper/lockup_test.go
+++ b/x/tier/keeper/lockup_test.go
@@ -533,3 +533,27 @@ func TestSubtractLockupUpdatesTotalLockups(t *testing.T) {
 	total = k.GetTotalLockupsAmount(ctx)
 	require.Equal(t, initialAmount.Sub(subtractAmount), total, "Total lockups amount should be 3500")
 }
+
+func TestRemoveLockupUpdatesTotalLockups(t *testing.T) {
+	k, ctx := keepertest.TierKeeper(t)
+
+	initialAmount := math.NewInt(5000)
+	subtractAmount := math.NewInt(5000)
+
+	delAddr, err := sdk.AccAddressFromBech32("source1m4f5a896t7fzd9vc7pfgmc3fxkj8n24s68fcw9")
+	require.NoError(t, err)
+	valAddr, err := sdk.ValAddressFromBech32("sourcevaloper1cy0p47z24ejzvq55pu3lesxwf73xnrnd0pzkqm")
+	require.NoError(t, err)
+
+	err = k.AddLockup(ctx, delAddr, valAddr, initialAmount)
+	require.NoError(t, err, "Adding lockup should not fail")
+
+	total := k.GetTotalLockupsAmount(ctx)
+	require.Equal(t, initialAmount, total, "Total lockups amount should be 5000")
+
+	err = k.SubtractLockup(ctx, delAddr, valAddr, subtractAmount)
+	require.NoError(t, err, "Subtracting lockup should not fail")
+
+	total = k.GetTotalLockupsAmount(ctx)
+	require.Equal(t, math.ZeroInt(), total, "Total lockups amount should be 0")
+}

--- a/x/tier/keeper/lockup_test.go
+++ b/x/tier/keeper/lockup_test.go
@@ -20,9 +20,9 @@ func TestSetAndGetLockup(t *testing.T) {
 	amount := math.NewInt(1000)
 
 	delAddr, err := sdk.AccAddressFromBech32("source1m4f5a896t7fzd9vc7pfgmc3fxkj8n24s68fcw9")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	valAddr, err := sdk.ValAddressFromBech32("sourcevaloper1cy0p47z24ejzvq55pu3lesxwf73xnrnd0pzkqm")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx = ctx.WithBlockHeight(creationHeight).WithBlockTime(now)
 
@@ -43,11 +43,12 @@ func TestAddLockup(t *testing.T) {
 	amount := math.NewInt(500)
 
 	delAddr, err := sdk.AccAddressFromBech32("source1m4f5a896t7fzd9vc7pfgmc3fxkj8n24s68fcw9")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	valAddr, err := sdk.ValAddressFromBech32("sourcevaloper1cy0p47z24ejzvq55pu3lesxwf73xnrnd0pzkqm")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
-	k.AddLockup(ctx, delAddr, valAddr, amount)
+	err = k.AddLockup(ctx, delAddr, valAddr, amount)
+	require.NoError(t, err)
 
 	lockup := k.GetLockupAmount(ctx, delAddr, valAddr)
 	require.Equal(t, amount, lockup)
@@ -61,11 +62,12 @@ func TestSubtractLockup(t *testing.T) {
 	invalidSubtractAmount := math.NewInt(2000)
 
 	delAddr, err := sdk.AccAddressFromBech32("source1m4f5a896t7fzd9vc7pfgmc3fxkj8n24s68fcw9")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	valAddr, err := sdk.ValAddressFromBech32("sourcevaloper1cy0p47z24ejzvq55pu3lesxwf73xnrnd0pzkqm")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
-	k.AddLockup(ctx, delAddr, valAddr, lockupAmount)
+	err = k.AddLockup(ctx, delAddr, valAddr, lockupAmount)
+	require.NoError(t, err)
 
 	// subtract a partial amount
 	err = k.SubtractLockup(ctx, delAddr, valAddr, partialSubtractAmount)
@@ -95,14 +97,14 @@ func TestGetAllLockups(t *testing.T) {
 	amount2 := math.NewInt(500)
 
 	delAddr1, err := sdk.AccAddressFromBech32("source1wjj5v5rlf57kayyeskncpu4hwev25ty645p2et")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	valAddr1, err := sdk.ValAddressFromBech32("sourcevaloper1cy0p47z24ejzvq55pu3lesxwf73xnrnd0pzkqm")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	delAddr2, err := sdk.AccAddressFromBech32("source1m4f5a896t7fzd9vc7pfgmc3fxkj8n24s68fcw9")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	valAddr2, err := sdk.ValAddressFromBech32("sourcevaloper13fj7t2yptf9k6ad6fv38434znzay4s4pjk0r4f")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	k.SetLockup(ctx, delAddr1, valAddr1, amount1)
 	k.SetLockup(ctx, delAddr2, valAddr2, amount2)
@@ -129,14 +131,14 @@ func TestGetAllUnlockingLockups(t *testing.T) {
 	amount2 := math.NewInt(500)
 
 	delAddr1, err := sdk.AccAddressFromBech32("source1wjj5v5rlf57kayyeskncpu4hwev25ty645p2et")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	valAddr1, err := sdk.ValAddressFromBech32("sourcevaloper1cy0p47z24ejzvq55pu3lesxwf73xnrnd0pzkqm")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	delAddr2, err := sdk.AccAddressFromBech32("source1m4f5a896t7fzd9vc7pfgmc3fxkj8n24s68fcw9")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	valAddr2, err := sdk.ValAddressFromBech32("sourcevaloper13fj7t2yptf9k6ad6fv38434znzay4s4pjk0r4f")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	k.SetUnlockingLockup(ctx, delAddr1, valAddr1, creationHeight1, amount1, timestamp1, timestamp1)
 	k.SetUnlockingLockup(ctx, delAddr2, valAddr2, creationHeight2, amount2, timestamp2, timestamp2)
@@ -165,11 +167,12 @@ func TestMustIterateLockups(t *testing.T) {
 	amount := math.NewInt(1000)
 
 	delAddr, err := sdk.AccAddressFromBech32("source1m4f5a896t7fzd9vc7pfgmc3fxkj8n24s68fcw9")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	valAddr, err := sdk.ValAddressFromBech32("sourcevaloper1cy0p47z24ejzvq55pu3lesxwf73xnrnd0pzkqm")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
-	k.AddLockup(ctx, delAddr, valAddr, amount)
+	err = k.AddLockup(ctx, delAddr, valAddr, amount)
+	require.NoError(t, err)
 
 	count := 0
 	k.MustIterateLockups(ctx, func(delAddr sdk.AccAddress, valAddr sdk.ValAddress, lockup types.Lockup) {
@@ -188,9 +191,9 @@ func TestMustIterateUnlockingLockups(t *testing.T) {
 	amount := math.NewInt(1000)
 
 	delAddr, err := sdk.AccAddressFromBech32("source1m4f5a896t7fzd9vc7pfgmc3fxkj8n24s68fcw9")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	valAddr, err := sdk.ValAddressFromBech32("sourcevaloper1cy0p47z24ejzvq55pu3lesxwf73xnrnd0pzkqm")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	k.SetUnlockingLockup(ctx, delAddr, valAddr, 1, amount, time.Time{}, time.Time{})
 
@@ -216,14 +219,14 @@ func TestIterateUnlockingLockups(t *testing.T) {
 	timestamp5 := time.Date(2006, time.January, 2, 15, 4, 5, 5, time.UTC)
 
 	delAddr1, err := sdk.AccAddressFromBech32("source1wjj5v5rlf57kayyeskncpu4hwev25ty645p2et")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	valAddr1, err := sdk.ValAddressFromBech32("sourcevaloper1cy0p47z24ejzvq55pu3lesxwf73xnrnd0pzkqm")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	delAddr2, err := sdk.AccAddressFromBech32("source1m4f5a896t7fzd9vc7pfgmc3fxkj8n24s68fcw9")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	valAddr2, err := sdk.ValAddressFromBech32("sourcevaloper13fj7t2yptf9k6ad6fv38434znzay4s4pjk0r4f")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx = ctx.WithBlockHeight(1)
 	k.SetUnlockingLockup(ctx, delAddr1, valAddr1, ctx.BlockHeight(), math.NewInt(1000), timestamp1, timestamp1)
@@ -272,9 +275,12 @@ func TestTotalAmountByAddr(t *testing.T) {
 	valAddr2, err := sdk.ValAddressFromBech32("sourcevaloper13fj7t2yptf9k6ad6fv38434znzay4s4pjk0r4f")
 	require.NoError(t, err)
 
-	k.AddLockup(ctx, delAddr1, valAddr1, math.NewInt(1000))
-	k.AddLockup(ctx, delAddr1, valAddr1, math.NewInt(500))
-	k.AddLockup(ctx, delAddr2, valAddr2, math.NewInt(700))
+	err = k.AddLockup(ctx, delAddr1, valAddr1, math.NewInt(1000))
+	require.NoError(t, err)
+	err = k.AddLockup(ctx, delAddr1, valAddr1, math.NewInt(500))
+	require.NoError(t, err)
+	err = k.AddLockup(ctx, delAddr2, valAddr2, math.NewInt(700))
+	require.NoError(t, err)
 
 	totalDel1 := k.TotalAmountByAddr(ctx, delAddr1)
 	require.Equal(t, math.NewInt(1500), totalDel1, "delAddr1 should have a total of 1500")
@@ -298,7 +304,8 @@ func TestHasLockup(t *testing.T) {
 
 	require.False(t, k.HasLockup(ctx, delAddr, valAddr))
 
-	k.AddLockup(ctx, delAddr, valAddr, math.NewInt(100))
+	err = k.AddLockup(ctx, delAddr, valAddr, math.NewInt(100))
+	require.NoError(t, err)
 	require.True(t, k.HasLockup(ctx, delAddr, valAddr))
 
 	err = k.SubtractLockup(ctx, delAddr, valAddr, math.NewInt(100))
@@ -463,4 +470,66 @@ func TestSubtractUnlockingLockup(t *testing.T) {
 
 	invalidUnlockingLockup := k.GetUnlockingLockup(ctx, delAddr, valAddr, creationHeight)
 	require.Nil(t, invalidUnlockingLockup)
+}
+
+func TestSetAndGetTotalLockupsAmount(t *testing.T) {
+	k, ctx := keepertest.TierKeeper(t)
+
+	total := k.GetTotalLockupsAmount(ctx)
+	require.True(t, total.IsZero(), "Initial total lockups amount should be zero")
+
+	expectedTotal := math.NewInt(1000)
+	err := k.SetTotalLockupsAmount(ctx, expectedTotal)
+	require.NoError(t, err, "Setting total lockups amount should not fail")
+
+	total = k.GetTotalLockupsAmount(ctx)
+	require.Equal(t, expectedTotal, total, "Total lockups amount should be 1000")
+}
+
+func TestAddLockupUpdatesTotalLockups(t *testing.T) {
+	k, ctx := keepertest.TierKeeper(t)
+
+	amount1 := math.NewInt(500)
+	amount2 := math.NewInt(1000)
+
+	delAddr, err := sdk.AccAddressFromBech32("source1m4f5a896t7fzd9vc7pfgmc3fxkj8n24s68fcw9")
+	require.NoError(t, err)
+	valAddr, err := sdk.ValAddressFromBech32("sourcevaloper1cy0p47z24ejzvq55pu3lesxwf73xnrnd0pzkqm")
+	require.NoError(t, err)
+
+	err = k.AddLockup(ctx, delAddr, valAddr, amount1)
+	require.NoError(t, err, "Adding first lockup should not fail")
+
+	total := k.GetTotalLockupsAmount(ctx)
+	require.Equal(t, amount1, total, "Total lockups amount should be 500")
+
+	err = k.AddLockup(ctx, delAddr, valAddr, amount2)
+	require.NoError(t, err, "Adding another lockup should not fail")
+
+	total = k.GetTotalLockupsAmount(ctx)
+	require.Equal(t, amount1.Add(amount2), total, "Total lockups amount should be 1500")
+}
+
+func TestSubtractLockupUpdatesTotalLockups(t *testing.T) {
+	k, ctx := keepertest.TierKeeper(t)
+
+	initialAmount := math.NewInt(5000)
+	subtractAmount := math.NewInt(1500)
+
+	delAddr, err := sdk.AccAddressFromBech32("source1m4f5a896t7fzd9vc7pfgmc3fxkj8n24s68fcw9")
+	require.NoError(t, err)
+	valAddr, err := sdk.ValAddressFromBech32("sourcevaloper1cy0p47z24ejzvq55pu3lesxwf73xnrnd0pzkqm")
+	require.NoError(t, err)
+
+	err = k.AddLockup(ctx, delAddr, valAddr, initialAmount)
+	require.NoError(t, err, "Adding lockup should not fail")
+
+	total := k.GetTotalLockupsAmount(ctx)
+	require.Equal(t, initialAmount, total, "Total lockups amount should be 5000")
+
+	err = k.SubtractLockup(ctx, delAddr, valAddr, subtractAmount)
+	require.NoError(t, err, "Subtracting lockup should not fail")
+
+	total = k.GetTotalLockupsAmount(ctx)
+	require.Equal(t, initialAmount.Sub(subtractAmount), total, "Total lockups amount should be 3500")
 }

--- a/x/tier/types/keys.go
+++ b/x/tier/types/keys.go
@@ -23,15 +23,16 @@ const (
 	// MemStoreKey defines the in-memory store key
 	MemStoreKey = "mem_tier"
 
-	// LockupKeyPrefix is the prefix to retrieve all Lockup
+	// LockupKeyPrefix is the prefix to retrieve all Lockups
 	LockupKeyPrefix = "Lockup/"
 
-	// UnlockingLockupKeyPrefix is the prefix to retrieve all UnlockingLockup
+	// UnlockingLockupKeyPrefix is the prefix to retrieve all UnlockingLockups
 	UnlockingLockupKeyPrefix = "UnlockingLockup/"
 )
 
 var (
-	ParamsKey = []byte("p_tier")
+	ParamsKey       = []byte("p_tier")
+	TotalLockupsKey = []byte("total_lockups")
 )
 
 func KeyPrefix(unlocking bool) []byte {


### PR DESCRIPTION
## Description

This PR adds changes to improve the inflation function performance, handle edge cases, and some minor fixes.

## Tasks
- [x] Add `GetTotalLockupsAmount` and `SetTotalLockupsAmount` methods.
- [x] Track total lockups amount in `AddLockup` and `SubtractLockup`. 
- [x] Use `GetTotalLockupsAmount` in the custom inflation function to avoid iterating all records every block.
- [x] Handle multiple edge cases during inflation calculations. 
- [x] Add new tests and update existing tests. 