### PR TITLE
fix: Panic after updating ibc-go to v8.3.1+

### DIFF
--- a/app/ibc.go
+++ b/app/ibc.go
@@ -127,6 +127,9 @@ func (app *App) registerIBCModules() {
 		app.MsgServiceRouter(),
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
+	// Fixes "panic: query router must not be nil" introduced in ibc-go v8.3.1
+	app.ICAHostKeeper.WithQueryRouter(app.GRPCQueryRouter())
+
 	app.ICAControllerKeeper = icacontrollerkeeper.NewKeeper(
 		app.appCodec,
 		app.GetKey(icacontrollertypes.StoreKey),


### PR DESCRIPTION
## Description

This PR fixes `panic: query router must not be nil` that was introduced after changes made in `ibc-go v8.3.1`.