### PR TITLE
feature: Enable ucredit fees

### DIFF
--- a/cmd/sourcehubd/cmd/config.go
+++ b/cmd/sourcehubd/cmd/config.go
@@ -30,7 +30,13 @@ func initAppConfig() (string, interface{}) {
 
 	// Optionally allow the chain developer to overwrite the SDK's default server config.
 	srvCfg := serverconfig.DefaultConfig()
-	srvCfg.MinGasPrices = fmt.Sprintf("%v%s", appparams.DefaultMinGasPrice, appparams.DefaultBondDenom)
+	srvCfg.MinGasPrices = fmt.Sprintf(
+		"%v%s,%v%s",
+		appparams.DefaultMinGasPrice,
+		appparams.MicroOpenDenom,
+		appparams.DefaultMinGasPrice,
+		appparams.MicroCreditDenom,
+	)
 	// The SDK's default minimum gas price is set to "" (empty value) inside
 	// app.toml. If left empty by validators, the node will halt on startup.
 	// However, the chain developer can set a default app.toml value for their

--- a/scripts/genesis-setup.sh
+++ b/scripts/genesis-setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/sh
 set -e
 
-CHAIN_ID="sourcehub"
+CHAIN_ID="sourcehub-dev"
 VALIDATOR="validator"
 NODE_NAME="node"
 BIN="build/sourcehubd"

--- a/scripts/genesis-setup.sh
+++ b/scripts/genesis-setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/sh
 set -e
 
-CHAIN_ID="sourcehub-dev"
+CHAIN_ID="sourcehub"
 VALIDATOR="validator"
 NODE_NAME="node"
 BIN="build/sourcehubd"
@@ -18,6 +18,6 @@ $BIN genesis gentx $VALIDATOR 100000000000000uopen --chain-id $CHAIN_ID --keyrin
 $BIN genesis collect-gentxs
 
 sed -i 's/^timeout_commit = .*/timeout_commit = "1s"/' ~/.sourcehub/config/config.toml
-sed -i 's/minimum-gas-prices = ""/minimum-gas-prices = "0.001uopen"/' ~/.sourcehub/config/app.toml
+sed -i 's/minimum-gas-prices = ""/minimum-gas-prices = "0.001uopen,0.001ucredit"/' ~/.sourcehub/config/app.toml
 
 echo "Validator Address $VALIDATOR_ADDR"


### PR DESCRIPTION
## Description

This PR enables fees in `ucredit` denom. 

The minimum gas price setting is identical for both `uopen` and `ucredit` denoms.