### PR TITLE
fix: Acp EndBlock error

### DIFF
--- a/x/acp/keeper/abci.go
+++ b/x/acp/keeper/abci.go
@@ -4,26 +4,26 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/sourcenetwork/acp_core/pkg/errors"
 	"github.com/sourcenetwork/sourcehub/x/acp/commitment"
 	"github.com/sourcenetwork/sourcehub/x/acp/types"
 )
 
 // EndBlocker is a function which should be called after processing a proposal and before finalizing a block,
-// as specified by the ABCI spec
+// as specified by the ABCI spec.
 //
 // Currently EndBlocker iterates over valid (non-expired) RegistrationCommitments and checks whether
-// they are still valid, otherwise flags them as expired
-func (k *Keeper) EndBlocker(goCtx context.Context) ([]*types.RegistrationsCommitment, error) {
+// they are still valid, otherwise flags them as expired.
+func (k *Keeper) EndBlocker(goCtx context.Context) []*types.RegistrationsCommitment {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	engine := k.GetACPEngine(ctx)
 	repo := k.GetRegistrationsCommitmentRepository(ctx)
 	service := commitment.NewCommitmentService(engine, repo)
 
+	// If an error occurs, return nil commitments and log the error
 	commitments, err := service.FlagExpiredCommitments(ctx)
 	if err != nil {
-		return nil, errors.Wrap("end blocker failed", err)
+		k.Logger().Error("EndBlocker failed", "error", err)
 	}
 
-	return commitments, nil
+	return commitments
 }

--- a/x/acp/keeper/abci_test.go
+++ b/x/acp/keeper/abci_test.go
@@ -38,12 +38,18 @@ func TestEndBlocker(t *testing.T) {
 	comm, err := service.SetNewCommitment(ctx, resp.Record.Policy.Id, commitment, coretypes.NewActor("test"), params, "source1234")
 	require.NoError(t, err)
 
+	// no expired commitments at this point
+	expired := k.EndBlocker(ctx)
+	require.Nil(t, expired)
+
 	// set commitment to expire
 	ctx = ctx.WithBlockTime(time.Now().Add(time.Nanosecond * 2))
 
-	expired, err := k.EndBlocker(ctx)
-	require.NoError(t, err)
+	// should return exactly one expired commitment
+	expired = k.EndBlocker(ctx)
+	require.NotNil(t, expired)
 	require.Len(t, expired, 1)
+
 	want := comm
 	want.Expired = true
 	require.Equal(t, want, expired[0])

--- a/x/acp/module/module.go
+++ b/x/acp/module/module.go
@@ -164,8 +164,8 @@ func (am AppModule) BeginBlock(_ context.Context) error {
 // EndBlock contains the logic that is automatically triggered at the end of each block.
 // The end block implementation is optional.
 func (am AppModule) EndBlock(ctx context.Context) error {
-	_, err := am.keeper.EndBlocker(ctx)
-	return err
+	am.keeper.EndBlocker(ctx)
+	return nil
 }
 
 // IsOnePerModuleType implements the depinject.OnePerModuleType interface.


### PR DESCRIPTION
## Description

This PR refactors acp `EndBlocker` to return `nil` commitments in case of error instead of propagating the error to `EndBlock`.