### PR TITLE
refactor: Encapsulate ACP Keeper methods

### DIFF
--- a/x/acp/keeper/abci.go
+++ b/x/acp/keeper/abci.go
@@ -15,8 +15,8 @@ import (
 // they are still valid, otherwise flags them as expired.
 func (k *Keeper) EndBlocker(goCtx context.Context) ([]*types.RegistrationsCommitment, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	engine := k.GetACPEngine(ctx)
-	repo := k.GetRegistrationsCommitmentRepository(ctx)
+	engine := k.getACPEngine(ctx)
+	repo := k.getRegistrationsCommitmentRepository(ctx)
 	service := commitment.NewCommitmentService(engine, repo)
 
 	commitments, err := service.FlagExpiredCommitments(ctx)

--- a/x/acp/keeper/abci_test.go
+++ b/x/acp/keeper/abci_test.go
@@ -26,7 +26,7 @@ func TestEndBlocker(t *testing.T) {
 		},
 	}
 
-	engine := k.GetACPEngine(ctx)
+	engine := k.getACPEngine(ctx)
 	ctx, err := utils.InjectPrincipal(ctx, "did:example:bob")
 	require.NoError(t, err)
 	resp, err := engine.CreatePolicy(ctx, &coretypes.CreatePolicyRequest{
@@ -35,8 +35,8 @@ func TestEndBlocker(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	repo := k.GetRegistrationsCommitmentRepository(ctx)
-	service := commitment.NewCommitmentService(k.GetACPEngine(ctx), repo)
+	repo := k.getRegistrationsCommitmentRepository(ctx)
+	service := commitment.NewCommitmentService(k.getACPEngine(ctx), repo)
 	commitment := make([]byte, 32)
 	comm, err := service.SetNewCommitment(ctx, resp.Record.Policy.Id, commitment, coretypes.NewActor("test"), params, "source1234")
 	require.NoError(t, err)

--- a/x/acp/keeper/keeper.go
+++ b/x/acp/keeper/keeper.go
@@ -68,8 +68,8 @@ func (k Keeper) Logger() log.Logger {
 	return k.logger.With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
 
-// GetAccessDecisionRepository returns the module's default access decision repository
-func (k *Keeper) GetAccessDecisionRepository(ctx sdk.Context) access_decision.Repository {
+// getAccessDecisionRepository returns the module's default access decision repository
+func (k *Keeper) getAccessDecisionRepository(ctx sdk.Context) access_decision.Repository {
 	kv := k.storeService.OpenKVStore(ctx)
 	prefixKey := []byte(types.AccessDecisionRepositoryKeyPrefix)
 	adapted := runtime.KVStoreAdapter(kv)
@@ -77,8 +77,8 @@ func (k *Keeper) GetAccessDecisionRepository(ctx sdk.Context) access_decision.Re
 	return access_decision.NewAccessDecisionRepository(adapted)
 }
 
-// GetACPEngine returns the module's default ACP Core Engine
-func (k *Keeper) GetACPEngine(ctx sdk.Context) *services.EngineService {
+// getACPEngine returns the module's default ACP Core Engine
+func (k *Keeper) getACPEngine(ctx sdk.Context) *services.EngineService {
 	kv := k.storeService.OpenKVStore(ctx)
 	adapted := runtime.KVStoreAdapter(kv)
 	raccoonAdapted := stores.RaccoonKVFromCosmos(adapted)
@@ -92,8 +92,8 @@ func (k *Keeper) GetACPEngine(ctx sdk.Context) *services.EngineService {
 	return services.NewACPEngine(runtime)
 }
 
-// GetRegistrationsCommitmentRepository returns the module's default Registration Commitment Repository
-func (k *Keeper) GetRegistrationsCommitmentRepository(ctx sdk.Context) *commitment.CommitmentRepository {
+// getRegistrationsCommitmentRepository returns the module's default Registration Commitment Repository
+func (k *Keeper) getRegistrationsCommitmentRepository(ctx sdk.Context) *commitment.CommitmentRepository {
 	cmtkv := k.storeService.OpenKVStore(ctx)
 	kv := cosmosadapter.NewFromCoreKVStore(cmtkv)
 	kv = primitives.NewPrefixedKV(kv, []byte(types.RegistrationsCommitmentKeyPrefix))
@@ -104,8 +104,8 @@ func (k *Keeper) GetRegistrationsCommitmentRepository(ctx sdk.Context) *commitme
 	return repo
 }
 
-// GetAmendmentEventRepository returns the module's default AmendmentEventRepository
-func (k *Keeper) GetAmendmentEventRepository(ctx sdk.Context) *registration.AmendmentEventRepository {
+// getAmendmentEventRepository returns the module's default AmendmentEventRepository
+func (k *Keeper) getAmendmentEventRepository(ctx sdk.Context) *registration.AmendmentEventRepository {
 	cmtkv := k.storeService.OpenKVStore(ctx)
 	kv := cosmosadapter.NewFromCoreKVStore(cmtkv)
 	kv = primitives.NewPrefixedKV(kv, []byte(types.AmendmentEventKeyPrefix))
@@ -117,27 +117,27 @@ func (k *Keeper) GetAmendmentEventRepository(ctx sdk.Context) *registration.Amen
 }
 
 // GetComitmentService returns the module's default CommitmentService instance
-func (k *Keeper) GetCommitmentService(ctx sdk.Context) *commitment.CommitmentService {
+func (k *Keeper) getCommitmentService(ctx sdk.Context) *commitment.CommitmentService {
 	return commitment.NewCommitmentService(
-		k.GetACPEngine(ctx),
-		k.GetRegistrationsCommitmentRepository(ctx),
+		k.getACPEngine(ctx),
+		k.getRegistrationsCommitmentRepository(ctx),
 	)
 }
 
-// GetRegistrationService returns the module's default RegistrationService instance
-func (k *Keeper) GetRegistrationService(ctx sdk.Context) *registration.RegistrationService {
+// getRegistrationService returns the module's default RegistrationService instance
+func (k *Keeper) getRegistrationService(ctx sdk.Context) *registration.RegistrationService {
 	return registration.NewRegistrationService(
-		k.GetACPEngine(ctx),
-		k.GetAmendmentEventRepository(ctx),
-		k.GetCommitmentService(ctx),
+		k.getACPEngine(ctx),
+		k.getAmendmentEventRepository(ctx),
+		k.getCommitmentService(ctx),
 	)
 }
 
-// GetPolicyCmdHandler returns the module's default PolicyCmd Handler instance
-func (k *Keeper) GetPolicyCmdHandler(ctx sdk.Context) *policy_cmd.Handler {
+// getPolicyCmdHandler returns the module's default PolicyCmd Handler instance
+func (k *Keeper) getPolicyCmdHandler(ctx sdk.Context) *policy_cmd.Handler {
 	return policy_cmd.NewPolicyCmdHandler(
-		k.GetACPEngine(ctx),
-		k.GetRegistrationService(ctx),
-		k.GetCommitmentService(ctx),
+		k.getACPEngine(ctx),
+		k.getRegistrationService(ctx),
+		k.getCommitmentService(ctx),
 	)
 }

--- a/x/acp/keeper/msg_server_bearer_policy_cmd.go
+++ b/x/acp/keeper/msg_server_bearer_policy_cmd.go
@@ -26,7 +26,7 @@ func (k msgServer) BearerPolicyCmd(goCtx context.Context, msg *types.MsgBearerPo
 		return nil, err
 	}
 
-	handler := k.GetPolicyCmdHandler(ctx)
+	handler := k.getPolicyCmdHandler(ctx)
 	result, err := handler.Dispatch(&cmdCtx, msg.Cmd)
 	if err != nil {
 		return nil, fmt.Errorf("PolicyCmd failed: %w", err)

--- a/x/acp/keeper/msg_server_check_access.go
+++ b/x/acp/keeper/msg_server_check_access.go
@@ -15,9 +15,9 @@ func (k msgServer) CheckAccess(goCtx context.Context, msg *types.MsgCheckAccess)
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	eventManager := ctx.EventManager()
 
-	repository := k.GetAccessDecisionRepository(ctx)
+	repository := k.getAccessDecisionRepository(ctx)
 	paramsRepository := access_decision.StaticParamsRepository{}
-	engine := k.GetACPEngine(ctx)
+	engine := k.getACPEngine(ctx)
 
 	record, err := engine.GetPolicy(goCtx, &coretypes.GetPolicyRequest{Id: msg.PolicyId})
 	if err != nil {

--- a/x/acp/keeper/msg_server_create_policy.go
+++ b/x/acp/keeper/msg_server_create_policy.go
@@ -14,7 +14,7 @@ import (
 func (k msgServer) CreatePolicy(goCtx context.Context, msg *types.MsgCreatePolicy) (*types.MsgCreatePolicyResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	engine := k.GetACPEngine(ctx)
+	engine := k.getACPEngine(ctx)
 
 	actorID, err := k.issueDIDFromAccountAddr(ctx, msg.Creator)
 	if err != nil {

--- a/x/acp/keeper/msg_server_direct_policy_cmd.go
+++ b/x/acp/keeper/msg_server_direct_policy_cmd.go
@@ -37,7 +37,7 @@ func (k msgServer) DirectPolicyCmd(goCtx context.Context, msg *types.MsgDirectPo
 		return nil, err
 	}
 
-	handler := k.GetPolicyCmdHandler(ctx)
+	handler := k.getPolicyCmdHandler(ctx)
 	result, err := handler.Dispatch(&cmdCtx, msg.Cmd)
 	if err != nil {
 		return nil, err

--- a/x/acp/keeper/msg_server_msg_edit_policy.go
+++ b/x/acp/keeper/msg_server_msg_edit_policy.go
@@ -14,7 +14,7 @@ import (
 func (k msgServer) EditPolicy(goCtx context.Context, msg *types.MsgEditPolicy) (*types.MsgEditPolicyResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	engine := k.GetACPEngine(ctx)
+	engine := k.getACPEngine(ctx)
 
 	did, err := k.issueDIDFromAccountAddr(ctx, msg.Creator)
 	if err != nil {

--- a/x/acp/keeper/msg_server_signed_policy_cmd.go
+++ b/x/acp/keeper/msg_server_signed_policy_cmd.go
@@ -28,7 +28,7 @@ func (k msgServer) SignedPolicyCmd(goCtx context.Context, msg *types.MsgSignedPo
 		return nil, err
 	}
 
-	handler := k.GetPolicyCmdHandler(ctx)
+	handler := k.getPolicyCmdHandler(ctx)
 	result, err := handler.Dispatch(&cmdCtx, payload.Cmd)
 	if err != nil {
 		return nil, err

--- a/x/acp/keeper/query_access_decision.go
+++ b/x/acp/keeper/query_access_decision.go
@@ -15,7 +15,7 @@ func (k Keeper) AccessDecision(goCtx context.Context, req *types.QueryAccessDeci
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	repository := k.GetAccessDecisionRepository(ctx)
+	repository := k.getAccessDecisionRepository(ctx)
 
 	decision, err := repository.Get(goCtx, req.Id)
 	if err != nil {

--- a/x/acp/keeper/query_access_decision_test.go
+++ b/x/acp/keeper/query_access_decision_test.go
@@ -54,7 +54,7 @@ func (s *queryAccessDecisionSuite) setup(t *testing.T) (context.Context, Keeper)
 		IssuedHeight: 100,
 	}
 
-	repo := keeper.GetAccessDecisionRepository(ctx)
+	repo := keeper.getAccessDecisionRepository(ctx)
 	err := repo.Set(ctx, decision)
 	require.NoError(t, err)
 

--- a/x/acp/keeper/query_filter_relationships.go
+++ b/x/acp/keeper/query_filter_relationships.go
@@ -18,7 +18,7 @@ func (k Keeper) FilterRelationships(goCtx context.Context, req *types.QueryFilte
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	engine := k.GetACPEngine(ctx)
+	engine := k.getACPEngine(ctx)
 
 	records, err := engine.FilterRelationships(goCtx, &coretypes.FilterRelationshipsRequest{
 		PolicyId: req.PolicyId,

--- a/x/acp/keeper/query_generate_commitment.go
+++ b/x/acp/keeper/query_generate_commitment.go
@@ -21,9 +21,9 @@ func (k Keeper) GenerateCommitment(goCtx context.Context, req *types.QueryGenera
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	engine := k.GetACPEngine(ctx)
+	engine := k.getACPEngine(ctx)
 
-	commitRepo := k.GetRegistrationsCommitmentRepository(ctx)
+	commitRepo := k.getRegistrationsCommitmentRepository(ctx)
 	commitmentService := commitment.NewCommitmentService(engine, commitRepo)
 
 	comm, err := commitmentService.BuildCommitment(ctx, req.PolicyId, req.Actor, req.Objects)

--- a/x/acp/keeper/query_hijack_attempts_by_policy.go
+++ b/x/acp/keeper/query_hijack_attempts_by_policy.go
@@ -16,7 +16,7 @@ func (k Keeper) HijackAttemptsByPolicy(goCtx context.Context, req *types.QueryHi
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	repo := k.GetAmendmentEventRepository(ctx)
+	repo := k.getAmendmentEventRepository(ctx)
 	iter, err := repo.ListHijackEventsByPolicy(ctx, req.PolicyId)
 	if err != nil {
 		return nil, err

--- a/x/acp/keeper/query_object_owner.go
+++ b/x/acp/keeper/query_object_owner.go
@@ -18,7 +18,7 @@ func (k Keeper) ObjectOwner(goCtx context.Context, req *types.QueryObjectOwnerRe
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	engine := k.GetACPEngine(ctx)
+	engine := k.getACPEngine(ctx)
 
 	result, err := engine.GetObjectRegistration(ctx, &coretypes.GetObjectRegistrationRequest{
 		PolicyId: req.PolicyId,

--- a/x/acp/keeper/query_policy.go
+++ b/x/acp/keeper/query_policy.go
@@ -18,7 +18,7 @@ func (k Keeper) Policy(goCtx context.Context, req *types.QueryPolicyRequest) (*t
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	engine := k.GetACPEngine(ctx)
+	engine := k.getACPEngine(ctx)
 
 	response, err := engine.GetPolicy(goCtx, &coretypes.GetPolicyRequest{
 		Id: req.Id,

--- a/x/acp/keeper/query_policy_ids.go
+++ b/x/acp/keeper/query_policy_ids.go
@@ -18,7 +18,7 @@ func (k Keeper) PolicyIds(goCtx context.Context, req *types.QueryPolicyIdsReques
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	engine := k.GetACPEngine(ctx)
+	engine := k.getACPEngine(ctx)
 
 	resp, err := engine.ListPolicies(ctx, &coretypes.ListPoliciesRequest{})
 	if err != nil {

--- a/x/acp/keeper/query_registrations_commitment.go
+++ b/x/acp/keeper/query_registrations_commitment.go
@@ -16,7 +16,7 @@ func (k Keeper) RegistrationsCommitment(goCtx context.Context, req *types.QueryR
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	repo := k.GetRegistrationsCommitmentRepository(ctx)
+	repo := k.getRegistrationsCommitmentRepository(ctx)
 
 	opt, err := repo.GetById(ctx, req.Id)
 	if err != nil {

--- a/x/acp/keeper/query_registrations_commitment_by_commitment.go
+++ b/x/acp/keeper/query_registrations_commitment_by_commitment.go
@@ -16,7 +16,7 @@ func (k Keeper) RegistrationsCommitmentByCommitment(goCtx context.Context, req *
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	repo := k.GetRegistrationsCommitmentRepository(ctx)
+	repo := k.getRegistrationsCommitmentRepository(ctx)
 
 	iter, err := repo.FilterByCommitment(ctx, req.Commitment)
 	if err != nil {

--- a/x/acp/keeper/query_validate_policy.go
+++ b/x/acp/keeper/query_validate_policy.go
@@ -11,7 +11,7 @@ import (
 
 func (k Keeper) ValidatePolicy(goCtx context.Context, req *types.QueryValidatePolicyRequest) (*types.QueryValidatePolicyResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	engine := k.GetACPEngine(ctx)
+	engine := k.getACPEngine(ctx)
 
 	resp, err := engine.ValidatePolicy(ctx, &coretypes.ValidatePolicyRequest{
 		Policy:      req.Policy,

--- a/x/acp/keeper/query_verify_access_request.go
+++ b/x/acp/keeper/query_verify_access_request.go
@@ -19,7 +19,7 @@ func (k Keeper) VerifyAccessRequest(goCtx context.Context, req *types.QueryVerif
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	engine := k.GetACPEngine(ctx)
+	engine := k.getACPEngine(ctx)
 
 	actorId := req.AccessRequest.Actor.Id
 	addr, err := sdk.AccAddressFromBech32(actorId)


### PR DESCRIPTION
What:
This PR refactors several methods in the ACP Keeper to private methods.

Why:
The original design of the keeper had an oversight where the usage of the Keeper in different SourceHub modules was not considered.
As such, this left several internal components of the ACP Module public to external modules, which broke encapsulation and incorrect usage of the ACP methods could lead to security compromises of the Policies in ACP