### PR TITLE
fix: Bulletin Genesis

### DIFF
--- a/testutil/e2e/e2e.go
+++ b/testutil/e2e/e2e.go
@@ -31,8 +31,7 @@ func (n *TestNetwork) Setup(t *testing.T) {
 	cfg, err := network.DefaultConfigWithAppConfig(injectConfig)
 	require.NoError(t, err)
 
-	// Test with multiple validators to ensure deterministic InitGenesis() logic
-	cfg.NumValidators = 3
+	cfg.NumValidators = 1
 	cfg.BondDenom = appparams.DefaultBondDenom
 	cfg.MinGasPrices = fmt.Sprintf(
 		"%s%s,%s%s",

--- a/testutil/e2e/e2e.go
+++ b/testutil/e2e/e2e.go
@@ -31,7 +31,8 @@ func (n *TestNetwork) Setup(t *testing.T) {
 	cfg, err := network.DefaultConfigWithAppConfig(injectConfig)
 	require.NoError(t, err)
 
-	cfg.NumValidators = 1
+	// Test with multiple validators to ensure deterministic InitGenesis() logic
+	cfg.NumValidators = 3
 	cfg.BondDenom = appparams.DefaultBondDenom
 	cfg.MinGasPrices = fmt.Sprintf(
 		"%s%s,%s%s",

--- a/x/bulletin/keeper/bulletin_test.go
+++ b/x/bulletin/keeper/bulletin_test.go
@@ -19,6 +19,24 @@ func TestGetNamespaceId(t *testing.T) {
 	require.Equal(t, getNamespaceId(id1), getNamespaceId(id3))
 }
 
+func TestHasPolicy(t *testing.T) {
+	k, ctx := setupKeeper(t)
+
+	require.False(t, k.hasPolicy(ctx))
+
+	k.SetPolicyId(ctx, "policy1")
+	require.True(t, k.hasPolicy(ctx))
+}
+
+func TestEnsurePolicy(t *testing.T) {
+	k, ctx := setupKeeper(t)
+
+	require.False(t, k.hasPolicy(ctx))
+
+	k.EnsurePolicy(ctx)
+	require.True(t, k.hasPolicy(ctx))
+}
+
 func TestHasNamespace(t *testing.T) {
 	k, ctx := setupKeeper(t)
 

--- a/x/bulletin/keeper/msg_server.go
+++ b/x/bulletin/keeper/msg_server.go
@@ -29,9 +29,12 @@ func (k *Keeper) UpdateParams(ctx context.Context, req *types.MsgUpdateParams) (
 // RegisterNamespace registers a new namespace resource under the genesis bulletin policy.
 // The namespace must have a unique, non-existent namespaceId.
 func (k *Keeper) RegisterNamespace(goCtx context.Context, msg *types.MsgRegisterNamespace) (*types.MsgRegisterNamespaceResponse, error) {
-	policyId := k.GetPolicyId(goCtx)
-	if policyId == "" {
-		return nil, types.ErrInvalidPolicyId
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	// Create module policy and claim capability if it does not exist yet
+	policyId, err := k.EnsurePolicy(ctx)
+	if err != nil {
+		return nil, types.ErrCouldNotEnsurePolicy
 	}
 
 	namespaceId := getNamespaceId(msg.Namespace)
@@ -43,8 +46,6 @@ func (k *Keeper) RegisterNamespace(goCtx context.Context, msg *types.MsgRegister
 	if err != nil {
 		return nil, err
 	}
-
-	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	err = RegisterNamespace(ctx, k, policyId, namespaceId, ownerDID, msg.Creator)
 	if err != nil {

--- a/x/bulletin/keeper/msg_server_test.go
+++ b/x/bulletin/keeper/msg_server_test.go
@@ -108,16 +108,6 @@ func TestMsgRegisterNamespace(t *testing.T) {
 			expErrMsg: "invalid namespace id",
 		},
 		{
-			name: "register namespace (error: invalid policy id)",
-			input: &types.MsgRegisterNamespace{
-				Creator:   baseAcc.Address,
-				Namespace: namespace,
-			},
-			setup:     func() {},
-			expErr:    true,
-			expErrMsg: "invalid policy id",
-		},
-		{
 			name: "register namespace (error: fetching capability for policy)",
 			input: &types.MsgRegisterNamespace{
 				Creator:   baseAcc.Address,
@@ -130,16 +120,16 @@ func TestMsgRegisterNamespace(t *testing.T) {
 			expErrMsg: "fetching capability for policy",
 		},
 		{
-			name: "register namespace (error: invalid policy id)",
+			name: "register namespace (error: fetching capability for invalid policy)",
 			input: &types.MsgRegisterNamespace{
 				Creator:   baseAcc.Address,
 				Namespace: namespace,
 			},
 			setup: func() {
-				k.SetPolicyId(ctx, "")
+				k.SetPolicyId(ctx, "invalidPolicy1")
 			},
 			expErr:    true,
-			expErrMsg: "invalid policy id",
+			expErrMsg: "fetching capability for policy invalidPolicy1",
 		},
 		{
 			name: "register namespace (no error)",

--- a/x/bulletin/types/errors.go
+++ b/x/bulletin/types/errors.go
@@ -21,4 +21,5 @@ var (
 	ErrInvalidPostProof          = sdkerrors.Register(ModuleName, 1110, "invalid post proof")
 	ErrCollaboratorAlreadyExists = sdkerrors.Register(ModuleName, 1111, "collaborator already exists")
 	ErrCollaboratorNotFound      = sdkerrors.Register(ModuleName, 1112, "collaborator not found")
+	ErrCouldNotEnsurePolicy      = sdkerrors.Register(ModuleName, 1113, "could not ensure policy")
 )


### PR DESCRIPTION
## Description

This PR fixes the non-deterministic behavior in the bulletin module’s `InitGenesis` by deferring policy creation. The policy is now lazily created during the first `RegisterNamespace` message, unless the chain is initialized from an exported state.