### PR TITLE
feat: Improve burnAllCredits

### DIFF
--- a/app/params/params.go
+++ b/app/params/params.go
@@ -13,7 +13,7 @@ const (
 	CreditDenom           = "credit"
 	CreditName            = "Source Credit"
 	CreditSymbol          = "CREDIT"
-	CreditDescription     = "Credit is the utility token for access services on SourceHub. Non transferrable."
+	CreditDescription     = "Credit is the utility token for access services on SourceHub. Non-transferable."
 	CreditFeeMultiplier   = 10
 
 	DefaultBondDenom   = MicroOpenDenom

--- a/x/tier/keeper/epoch_hook.go
+++ b/x/tier/keeper/epoch_hook.go
@@ -37,7 +37,7 @@ func (h EpochHooks) BeforeEpochStart(ctx context.Context, epochIdentifier string
 		return errorsmod.Wrapf(err, "burn all credits")
 	}
 
-	err = h.keeper.resetAllCredits(ctx)
+	err = h.keeper.resetAllCredits(ctx, epochNumber)
 	if err != nil {
 		return errorsmod.Wrapf(err, "reset all credits")
 	}


### PR DESCRIPTION
## Description

This PR improves `burnAllCredits` to iterate over the lockup records instead of scanning all bank balances, since `ucredit` tokens are non-transferrable. It also enhances telemetry in `resetAllCredits` and updates the corresponding tests.