### PR TITLE
fix: Create policy cli command

### DIFF
--- a/x/acp/client/cli/query_filter_relationships.go
+++ b/x/acp/client/cli/query_filter_relationships.go
@@ -16,12 +16,12 @@ func CmdQueryFilterRelationships() *cobra.Command {
 		Use:   "filter-relationships [policy-id] [object] [relation] [subject]",
 		Short: "Filters through relationships in a policy",
 		Long: `Filters thourgh all relationships in a Policy. 
-                Performs a lookup using the object, relation and subject filters.
-                Uses a mini grammar as describe:
-                object := resource:id | *
-                relation := name | *
-                subject := id | *
-                Returns`,
+		Performs a lookup using the object, relation and subject filters.
+		Uses a mini grammar as describe:
+		object := resource:id | *
+		relation := name | *
+		subject := id | *
+		Returns`,
 		Args:    cobra.ExactArgs(4),
 		Aliases: []string{"relationships"},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/x/acp/client/cli/tx_create_policy.go
+++ b/x/acp/client/cli/tx_create_policy.go
@@ -22,16 +22,16 @@ func CmdCreatePolicy() *cobra.Command {
 		Use:   "create-policy [marshaling_type] {policy_file | -}",
 		Short: "Broadcast message CreatePolicy",
 		Long: `
-                       Broadcast message CreatePolicy.
+		Broadcast message CreatePolicy.
 
-                       marshaling_type specifies the marshaling format for the policy.
-                       Defaults to SHORT_YAML.
-                       See PolicyMarshalingType for accepted values.
+		marshaling_type specifies the marshaling format for the policy.
+		Defaults to SHORT_YAML.
+		See PolicyMarshalingType for accepted values.
 
-                       policy_file specifies a file whose contents is the policy.
-                       - to read from stdin.
-                       Note: if reading from stdin make sure flag --yes is set.`,
-		Args: cobra.ExactArgs(1),
+		policy_file specifies a file whose contents is the policy.
+		- to read from stdin.
+		Note: if reading from stdin make sure flag --yes is set.`,
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			var policyFile string
 			var marshalingType coretypes.PolicyMarshalingType

--- a/x/acp/client/cli/tx_edit_policy.go
+++ b/x/acp/client/cli/tx_edit_policy.go
@@ -22,13 +22,13 @@ func CmdEditPolicy() *cobra.Command {
 		Use:   "edit-policy policy_id {policy_file | -}",
 		Short: "Broadcast message EditPolicy",
 		Long: `
-                       Broadcast message EditPolicy.
+		Broadcast message EditPolicy.
 
-					   policy_id is the id of the policy that is going to be edited.
+		policy_id is the id of the policy that is going to be edited.
 
-                       policy_file specifies a file whose contents is the policy.
-                       - to read from stdin.
-                       Note: if reading from stdin make sure flag --yes is set.`,
+		policy_file specifies a file whose contents is the policy.
+		- to read from stdin.
+		Note: if reading from stdin make sure flag --yes is set.`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			policyId := args[0]


### PR DESCRIPTION
## Description

This PR fixes the number of arguments in the `create-policy` cli command to allow setting the `marshaling_type`.