### PR TITLE
fix: Init files cmd

### DIFF
--- a/app/faucet.go
+++ b/app/faucet.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 
 	faucettypes "github.com/sourcenetwork/sourcehub/app/faucet/types"
-	"github.com/sourcenetwork/sourcehub/app/params"
 	appparams "github.com/sourcenetwork/sourcehub/app/params"
 )
 
@@ -34,14 +33,9 @@ const (
 	DefaultAllowanceExpirationDays = 30
 )
 
-// FaucetConfig defines the configuration for the faucet service.
-type FaucetConfig struct {
-	EnableFaucet bool `mapstructure:"enable_faucet"`
-}
-
 // getFaucetConfig extracts faucet configuration from app options.
-func getFaucetConfig(appOpts servertypes.AppOptions) FaucetConfig {
-	var faucetConfig FaucetConfig
+func getFaucetConfig(appOpts servertypes.AppOptions) appparams.FaucetConfig {
+	var faucetConfig appparams.FaucetConfig
 
 	if enableFaucet := appOpts.Get("faucet.enable_faucet"); enableFaucet != nil {
 		if boolVal, ok := enableFaucet.(bool); ok {
@@ -85,7 +79,7 @@ func (app *App) zeroFeeTxsAllowed() bool {
 
 // hasAddressRequested checks if an address has already requested funds.
 func (app *App) hasAddressRequested(address string) bool {
-	store := app.BaseApp.CommitMultiStore().GetKVStore(app.GetKey(params.FaucetStoreKey))
+	store := app.BaseApp.CommitMultiStore().GetKVStore(app.GetKey(appparams.FaucetStoreKey))
 	if store == nil {
 		return false
 	}
@@ -94,7 +88,7 @@ func (app *App) hasAddressRequested(address string) bool {
 
 // recordAddressRequested records that an address has requested funds.
 func (app *App) recordAddressRequested(address string, amount sdk.Coins, txHash string) error {
-	store := app.BaseApp.CommitMultiStore().GetKVStore(app.GetKey(params.FaucetStoreKey))
+	store := app.BaseApp.CommitMultiStore().GetKVStore(app.GetKey(appparams.FaucetStoreKey))
 	if store == nil {
 		return fmt.Errorf("faucet store not found")
 	}
@@ -116,7 +110,7 @@ func (app *App) recordAddressRequested(address string, amount sdk.Coins, txHash 
 
 // getRequestCount returns the number of addresses that have requested funds.
 func (app *App) getRequestCount() int {
-	store := app.BaseApp.CommitMultiStore().GetKVStore(app.GetKey(params.FaucetStoreKey))
+	store := app.BaseApp.CommitMultiStore().GetKVStore(app.GetKey(appparams.FaucetStoreKey))
 	if store == nil {
 		return 0
 	}

--- a/app/params/params.go
+++ b/app/params/params.go
@@ -41,3 +41,8 @@ const FaucetStoreKey = "faucet"
 type AppParamsGenesis struct {
 	AllowZeroFeeTxs bool `json:"allow_zero_fee_txs"`
 }
+
+// FaucetConfig defines the configuration for the faucet service.
+type FaucetConfig struct {
+	EnableFaucet bool `mapstructure:"enable_faucet"`
+}

--- a/cmd/sourcehubd/cmd/config.go
+++ b/cmd/sourcehubd/cmd/config.go
@@ -12,12 +12,7 @@ import (
 type CustomAppConfig struct {
 	serverconfig.Config `mapstructure:",squash"`
 
-	Faucet FaucetConfig `mapstructure:"faucet"`
-}
-
-// FaucetConfig defines the configuration for the faucet service
-type FaucetConfig struct {
-	EnableFaucet bool `mapstructure:"enable_faucet"`
+	Faucet appparams.FaucetConfig `mapstructure:"faucet"`
 }
 
 // initCometBFTConfig helps to override default CometBFT Config values.
@@ -61,7 +56,7 @@ func initAppConfig() (string, interface{}) {
 
 	customAppConfig := CustomAppConfig{
 		Config: *srvCfg,
-		Faucet: FaucetConfig{
+		Faucet: appparams.FaucetConfig{
 			EnableFaucet: false,
 		},
 	}

--- a/cmd/sourcehubd/cmd/testnet.go
+++ b/cmd/sourcehubd/cmd/testnet.go
@@ -64,7 +64,7 @@ var (
 	flagStakeTokens       = "stake-tokens"
 	flagOpenTokens        = "uopen-tokens"
 	flagCreditTokens      = "ucredit-tokens"
-	flagAddFaucet         = "faucet"
+	flagAddFaucet         = "faucet-amount"
 	flagNodeDirPrefix     = "node-dir-prefix"
 	flagNodeDaemonHome    = "node-daemon-home"
 	flagStartingIPAddress = "starting-ip-address"


### PR DESCRIPTION
## Description

This PR updates the faucet flag in the `sourcehubd testnet init-files` cmd from `--faucet` to `--faucet-amount` to prevent overlap with the `faucet` app config, and performs minor refactoring of the faucet config to reduce code duplication.