### PR TITLE
fix: Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,10 @@
 #
 # The workflow will not run if there is no tag pushed with a "v" prefix and no change pushed to your 
 # default branch.
-on: push
+on:
+  push:
+    tags:
+      - 'v*.*.*'
 
 jobs:
   might_release:
@@ -23,8 +26,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-        
-      - name: Prepare Release Variables 
+
+      - name: Prepare Release Variables
         id: vars
         uses: ignite/cli/actions/release/vars@main
 
@@ -40,7 +43,7 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
-      - name: Issue Release Assets 
+      - name: Issue Release Assets
         uses: ignite/cli/actions/cli@main
         if: ${{ steps.vars.outputs.should_release == 'true' }}
         env:
@@ -63,6 +66,6 @@ jobs:
         with:
           tag_name: ${{ steps.vars.outputs.tag_name }}
           files: release/*
-          prerelease: true 
+          prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This PR updates the release workflow so that releases are only triggered by version tags, preventing automatic creation of "latest" releases on default branch pushes.