### PR TITLE
fix: JWS token validation

### DIFF
--- a/app/ante/extension.go
+++ b/app/ante/extension.go
@@ -72,6 +72,7 @@ func (eod ExtensionOptionsDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simu
 	// Validate JWS format, signature, required claims, and timing
 	did, authorizedAccount, err := validateJWSExtension(ctx, jwsOpt.BearerToken, currentTime, skipAuthValidation)
 	if err != nil {
+		ctx.Logger().Error("Bearer token validation failed", "error", err, "did", did)
 		return ctx, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "bearer token validation failed: %v", err)
 	}
 

--- a/app/ante/extension_utils.go
+++ b/app/ante/extension_utils.go
@@ -130,7 +130,7 @@ func validateBearerToken(token *antetypes.BearerToken, currentTime *time.Time, s
 	now := currentTime.Unix()
 
 	if now > token.ExpirationTime {
-		return fmt.Errorf("token expired: current time %d > expiration time %d", token.ExpirationTime, now)
+		return fmt.Errorf("token expired: current time %d > expiration time %d", now, token.ExpirationTime)
 	}
 
 	return nil

--- a/x/hub/keeper/jws_token.go
+++ b/x/hub/keeper/jws_token.go
@@ -50,6 +50,8 @@ func (k *Keeper) SetJWSToken(ctx context.Context, record *types.JWSTokenRecord) 
 		if _, err := sdk.AccAddressFromBech32(record.AuthorizedAccount); err != nil {
 			return fmt.Errorf("invalid authorized account address: %w", err)
 		}
+	} else if !k.IsBearerAuthIgnored(ctx) {
+		return fmt.Errorf("authorized account is required when bearer auth is enabled")
 	}
 
 	bz, err := k.cdc.Marshal(record)

--- a/x/hub/keeper/jws_token.go
+++ b/x/hub/keeper/jws_token.go
@@ -45,17 +45,11 @@ func (k *Keeper) SetJWSToken(ctx context.Context, record *types.JWSTokenRecord) 
 		return fmt.Errorf("issuer DID cannot be empty")
 	}
 
-	if record.AuthorizedAccount == "" {
-		return fmt.Errorf("authorized account cannot be empty")
-	}
-
-	if _, err := sdk.AccAddressFromBech32(record.AuthorizedAccount); err != nil {
-		return fmt.Errorf("invalid authorized account address: %w", err)
-	}
-
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	if !record.ExpiresAt.IsZero() && record.ExpiresAt.Before(sdkCtx.BlockTime()) {
-		return fmt.Errorf("expiration time cannot be in the past")
+	// Validate authorized account if provided
+	if record.AuthorizedAccount != "" {
+		if _, err := sdk.AccAddressFromBech32(record.AuthorizedAccount); err != nil {
+			return fmt.Errorf("invalid authorized account address: %w", err)
+		}
 	}
 
 	bz, err := k.cdc.Marshal(record)
@@ -73,12 +67,14 @@ func (k *Keeper) SetJWSToken(ctx context.Context, record *types.JWSTokenRecord) 
 	didKeyWithoutPrefix := didKey[len(types.JWSTokenByDIDKeyPrefix):]
 	didStore.Set(didKeyWithoutPrefix, []byte{0x01}) // Just a marker, actual data is in primary store
 
-	// Store in account index
-	accountStore := k.jwsTokenByAccountStore(ctx)
-	accountKey := types.JWSTokenByAccountKey(record.AuthorizedAccount, record.TokenHash)
-	// Remove the prefix since we're already in the account prefix store
-	accountKeyWithoutPrefix := accountKey[len(types.JWSTokenByAccountKeyPrefix):]
-	accountStore.Set(accountKeyWithoutPrefix, []byte{0x01}) // Just a marker
+	// Store in account index only if authorized account is provided
+	if record.AuthorizedAccount != "" {
+		accountStore := k.jwsTokenByAccountStore(ctx)
+		accountKey := types.JWSTokenByAccountKey(record.AuthorizedAccount, record.TokenHash)
+		// Remove the prefix since we're already in the account prefix store
+		accountKeyWithoutPrefix := accountKey[len(types.JWSTokenByAccountKeyPrefix):]
+		accountStore.Set(accountKeyWithoutPrefix, []byte{0x01}) // Just a marker
+	}
 
 	return nil
 }
@@ -119,11 +115,13 @@ func (k *Keeper) DeleteJWSToken(ctx context.Context, tokenHash string) error {
 	didKeyWithoutPrefix := didKey[len(types.JWSTokenByDIDKeyPrefix):]
 	didStore.Delete(didKeyWithoutPrefix)
 
-	// Delete from account index
-	accountStore := k.jwsTokenByAccountStore(ctx)
-	accountKey := types.JWSTokenByAccountKey(record.AuthorizedAccount, tokenHash)
-	accountKeyWithoutPrefix := accountKey[len(types.JWSTokenByAccountKeyPrefix):]
-	accountStore.Delete(accountKeyWithoutPrefix)
+	// Delete from account index only if authorized account was provided
+	if record.AuthorizedAccount != "" {
+		accountStore := k.jwsTokenByAccountStore(ctx)
+		accountKey := types.JWSTokenByAccountKey(record.AuthorizedAccount, tokenHash)
+		accountKeyWithoutPrefix := accountKey[len(types.JWSTokenByAccountKeyPrefix):]
+		accountStore.Delete(accountKeyWithoutPrefix)
+	}
 
 	return nil
 }
@@ -298,6 +296,11 @@ func (k *Keeper) StoreOrUpdateJWSToken(
 	if found {
 		// Token exists, update usage timestamp
 		return k.RecordJWSTokenUsage(ctx, tokenHash)
+	}
+
+	// Validate that new tokens aren't already expired
+	if !expiresAt.IsZero() && expiresAt.Before(sdk.UnwrapSDKContext(ctx).BlockTime()) {
+		return fmt.Errorf("cannot create token with expiration time in the past")
 	}
 
 	// Create new token record


### PR DESCRIPTION
## Description

This PR fixes a bug with jws token validation, allowing to invalidate expired tokens while preventing expired tokens from being created. Authorized account validation / indexing is performed only if it is set.