### PR TITLE
fix: Bulletin keys

### DIFF
--- a/x/bulletin/keeper/bulletin.go
+++ b/x/bulletin/keeper/bulletin.go
@@ -140,7 +140,8 @@ func (k *Keeper) mustIteratePosts(ctx context.Context, cb func(post types.Post))
 func (k *Keeper) mustIterateNamespacePosts(ctx context.Context, namespaceId string, cb func(namespaceId string, post types.Post)) {
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.PostKeyPrefix))
-	iterator := storetypes.KVStorePrefixIterator(store, []byte(namespaceId+"/"))
+	sanitizedPrefix := types.SanitizeKeyPart(namespaceId) + "/"
+	iterator := storetypes.KVStorePrefixIterator(store, []byte(sanitizedPrefix))
 
 	defer iterator.Close()
 

--- a/x/bulletin/keeper/bulletin.go
+++ b/x/bulletin/keeper/bulletin.go
@@ -74,7 +74,7 @@ func (k *Keeper) getPost(ctx context.Context, namespaceId string, postId string)
 	return &post
 }
 
-// getCollaborator retrieves a post based on existing namespaceId and collaboratorDID.
+// getCollaborator retrieves a namespace collaborator based on existing namespaceId and collaboratorDID.
 func (k *Keeper) getCollaborator(ctx context.Context, namespaceId string, collaboratorDID string) *types.Collaborator {
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.CollaboratorKeyPrefix))

--- a/x/bulletin/keeper/grpc_query.go
+++ b/x/bulletin/keeper/grpc_query.go
@@ -158,8 +158,9 @@ func (k *Keeper) getNamespaceCollaboratorsPaginated(ctx context.Context, namespa
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.CollaboratorKeyPrefix))
 
+	sanitizedPrefix := types.SanitizeKeyPart(namespaceId) + "/"
 	onResult := func(key []byte, value []byte) error {
-		if !bytes.HasPrefix(key, []byte(namespaceId+"/")) {
+		if !bytes.HasPrefix(key, []byte(sanitizedPrefix)) {
 			return nil
 		}
 		var collaborator types.Collaborator
@@ -184,8 +185,9 @@ func (k *Keeper) getNamespacePostsPaginated(ctx context.Context, namespaceId str
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.PostKeyPrefix))
 
+	sanitizedPrefix := types.SanitizeKeyPart(namespaceId) + "/"
 	onResult := func(key []byte, value []byte) error {
-		if !bytes.HasPrefix(key, []byte(namespaceId+"/")) {
+		if !bytes.HasPrefix(key, []byte(sanitizedPrefix)) {
 			return nil
 		}
 		var post types.Post

--- a/x/bulletin/types/keys.go
+++ b/x/bulletin/types/keys.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"strings"
 )
 
 const (
@@ -33,30 +34,46 @@ func KeyPrefix(p string) []byte {
 	return []byte(p)
 }
 
+// SanitizeKeyPart replaces "/" with ":" in key parts to prevent key collisions.
+func SanitizeKeyPart(part string) string {
+	return strings.ReplaceAll(part, "/", ":")
+}
+
+// unsanitizeKeyPart restores "/" from ":" in key parts.
+func unsanitizeKeyPart(part string) string {
+	return strings.ReplaceAll(part, ":", "/")
+}
+
 // PostKey builds and returns the store key to store/retrieve the Post.
 func PostKey(namespaceId string, postId string) []byte {
+	sanitizedNamespaceId := SanitizeKeyPart(namespaceId)
+	sanitizedPostId := SanitizeKeyPart(postId)
+
 	// Precompute buffer size
-	size := len(namespaceId) + 1 + len(postId)
+	size := len(sanitizedNamespaceId) + 1 + len(sanitizedPostId)
 	buf := make([]byte, 0, size)
 
 	// Append bytes to the buffer
-	buf = append(buf, namespaceId...)
+	buf = append(buf, sanitizedNamespaceId...)
 	buf = append(buf, '/')
-	buf = append(buf, postId...)
+	buf = append(buf, sanitizedPostId...)
 
 	return buf
 }
 
 // CollaboratorKey builds and returns the store key to store/retrieve the Actor.
 func CollaboratorKey(namespaceId string, collaboratorDID string) []byte {
+	sanitizedNamespaceId := SanitizeKeyPart(namespaceId)
+	sanitizedCollaboratorDID := SanitizeKeyPart(collaboratorDID)
+
 	// Precompute buffer size
-	size := len(namespaceId) + 1 + len(collaboratorDID)
+	size := len(sanitizedNamespaceId) + 1 + len(sanitizedCollaboratorDID)
 	buf := make([]byte, 0, size)
 
 	// Append bytes to the buffer
-	buf = append(buf, namespaceId...)
+	buf = append(buf, sanitizedNamespaceId...)
 	buf = append(buf, '/')
-	buf = append(buf, collaboratorDID...)
+	buf = append(buf, sanitizedCollaboratorDID...)
 
 	return buf
 }
@@ -68,7 +85,10 @@ func ParsePostKey(key []byte) (namespaceId string, postId string) {
 		panic("invalid post key format: expected format namespaceId/postId")
 	}
 
-	return string(parts[0]), string(parts[1])
+	namespaceId = unsanitizeKeyPart(string(parts[0]))
+	postId = unsanitizeKeyPart(string(parts[1]))
+
+	return namespaceId, postId
 }
 
 // ParseCollaboratorKey retrieves namespaceId and actorDID from the Collaborator key.
@@ -78,7 +98,10 @@ func ParseCollaboratorKey(key []byte) (namespaceId string, actorDID string) {
 		panic("invalid post key format: expected format namespaceId/actorDID")
 	}
 
-	return string(parts[0]), string(parts[1])
+	namespaceId = unsanitizeKeyPart(string(parts[0]))
+	actorDID = unsanitizeKeyPart(string(parts[1]))
+
+	return namespaceId, actorDID
 }
 
 // GeneratePostId generates deterministic post id from namespaceId and post payload.

--- a/x/bulletin/types/keys.go
+++ b/x/bulletin/types/keys.go
@@ -34,14 +34,14 @@ func KeyPrefix(p string) []byte {
 	return []byte(p)
 }
 
-// SanitizeKeyPart replaces "/" with ":" in key parts to prevent key collisions.
+// SanitizeKeyPart replaces "/" with "|" in key parts to prevent key collisions.
 func SanitizeKeyPart(part string) string {
-	return strings.ReplaceAll(part, "/", ":")
+	return strings.ReplaceAll(part, "/", "|")
 }
 
-// unsanitizeKeyPart restores "/" from ":" in key parts.
+// unsanitizeKeyPart restores "/" from "|" in key parts.
 func unsanitizeKeyPart(part string) string {
-	return strings.ReplaceAll(part, ":", "/")
+	return strings.ReplaceAll(part, "|", "/")
 }
 
 // PostKey builds and returns the store key to store/retrieve the Post.


### PR DESCRIPTION
## Description

This PR improves the bulletin keys logic to sanitize key parts and use `|` instead of `/` to prevent possible key collisions.