### PR TITLE
fix: build arm64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,6 +41,13 @@ jobs:
         with:
           cosign-release: 'v2.2.4'
 
+      # Set up QEMU so we can cross-build the arm64 image on the amd64 runner.
+      # Without a native arm64 image, Apple Silicon runs the amd64 build under
+      # emulation and blst's x86 asm hits SIGILL. See issue #123.
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
+
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
@@ -79,6 +86,7 @@ jobs:
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
closes https://github.com/sourcenetwork/sourcehub/issues/123

We need an arm64 build for mizu testing, is a pain to have to build locally vs using an upstream ghcr docker image version

## Summary

Confirming it works

<img width="1630" height="1656" alt="image" src="https://github.com/user-attachments/assets/d79ad480-e6d0-4937-85fd-986938e4fd26" />
