### PR TITLE
fix: Restrict provider identity to trusted relays

### DIFF
--- a/app/ante/extension_test.go
+++ b/app/ante/extension_test.go
@@ -56,6 +56,7 @@ func buildExtensionTestTx(
 	creator string,
 	feeGranter sdk.AccAddress,
 	authorizedAccount string,
+	providerToken *antetypes.ProviderToken,
 ) (sdk.Tx, string) {
 	t.Helper()
 	s.txBuilder = s.clientCtx.TxConfig.NewTxBuilder()
@@ -68,7 +69,7 @@ func buildExtensionTestTx(
 		s.txBuilder.SetFeeGranter(feeGranter)
 	}
 
-	bearerToken, userDID := test.GenerateSignedJWSWithMatchingDID(t, authorizedAccount)
+	bearerToken, userDID := test.GenerateSignedJWSWithProvider(t, authorizedAccount, providerToken)
 	jwsOpt, err := codectypes.NewAnyWithValue(&antetypes.JWSExtensionOption{BearerToken: bearerToken})
 	require.NoError(t, err)
 	extendedBuilder, ok := s.txBuilder.(client.ExtendedTxBuilder)
@@ -926,12 +927,45 @@ func TestExtensionOptionsDecorator_TrustedRelay(t *testing.T) {
 	accs := s.CreateTestAccounts(2)
 	worker := accs[0].acc.GetAddress()
 	feeGranter := accs[1].acc.GetAddress()
-	tx, userDID := buildExtensionTestTx(t, s, accs[0], worker.String(), feeGranter, "")
+	tx, userDID := buildExtensionTestTx(t, s, accs[0], worker.String(), feeGranter, "", nil)
 
 	newCtx, err := NewExtensionOptionsDecorator(relayHubKeeper(feeGranter)).
 		AnteHandle(s.ctx, tx, false, nextAnte)
 	require.NoError(t, err)
 	require.Equal(t, userDID, getExtractedDIDFromContext(newCtx))
+	require.Equal(t, feeGranter.String(), getTrustedRelayFeeGranterFromContext(newCtx))
+}
+
+func TestExtensionOptionsDecorator_RejectsProviderIdentityWithoutTrustedRelay(t *testing.T) {
+	s := SetupTestSuite(t, true)
+	account := s.CreateTestAccounts(1)[0]
+	address := account.acc.GetAddress()
+	tx, _ := buildExtensionTestTx(t, s, account, address.String(), nil, address.String(), &antetypes.ProviderToken{
+		ProviderName: "google",
+		UserID:       "victim@example.com",
+		ActorDID:     "did:opk:victim",
+	})
+
+	_, err := NewExtensionOptionsDecorator(nil).AnteHandle(s.ctx, tx, false, nextAnte)
+	require.ErrorContains(t, err, "provider token requires a trusted relay")
+}
+
+func TestExtensionOptionsDecorator_AcceptsProviderIdentityFromTrustedRelay(t *testing.T) {
+	s := SetupTestSuite(t, true)
+	accs := s.CreateTestAccounts(2)
+	worker := accs[0].acc.GetAddress()
+	feeGranter := accs[1].acc.GetAddress()
+	actorDID := "did:opk:user"
+	tx, _ := buildExtensionTestTx(t, s, accs[0], worker.String(), feeGranter, "", &antetypes.ProviderToken{
+		ProviderName: "google",
+		UserID:       "user@example.com",
+		ActorDID:     actorDID,
+	})
+
+	newCtx, err := NewExtensionOptionsDecorator(relayHubKeeper(feeGranter)).
+		AnteHandle(s.ctx, tx, false, nextAnte)
+	require.NoError(t, err)
+	require.Equal(t, actorDID, getExtractedDIDFromContext(newCtx))
 	require.Equal(t, feeGranter.String(), getTrustedRelayFeeGranterFromContext(newCtx))
 }
 
@@ -941,7 +975,7 @@ func TestExtensionOptionsDecorator_RejectsUntrustedRelay(t *testing.T) {
 	worker := accs[0].acc.GetAddress()
 	feeGranter := accs[1].acc.GetAddress()
 	trusted := accs[2].acc.GetAddress()
-	tx, _ := buildExtensionTestTx(t, s, accs[0], worker.String(), feeGranter, "")
+	tx, _ := buildExtensionTestTx(t, s, accs[0], worker.String(), feeGranter, "", nil)
 
 	_, err := NewExtensionOptionsDecorator(relayHubKeeper(trusted)).
 		AnteHandle(s.ctx, tx, false, nextAnte)
@@ -953,7 +987,7 @@ func TestExtensionOptionsDecorator_RejectsRelayWithoutFeeGranter(t *testing.T) {
 	accs := s.CreateTestAccounts(2)
 	worker := accs[0].acc.GetAddress()
 	trusted := accs[1].acc.GetAddress()
-	tx, _ := buildExtensionTestTx(t, s, accs[0], worker.String(), nil, "")
+	tx, _ := buildExtensionTestTx(t, s, accs[0], worker.String(), nil, "", nil)
 
 	_, err := NewExtensionOptionsDecorator(relayHubKeeper(trusted)).
 		AnteHandle(s.ctx, tx, false, nextAnte)
@@ -988,7 +1022,7 @@ func TestExtensionOptionsDecorator_PropagatesTokenStoreFailure(t *testing.T) {
 	s := SetupTestSuite(t, true)
 	accs := s.CreateTestAccounts(1)
 	creator := accs[0].acc.GetAddress().String()
-	tx, _ := buildExtensionTestTx(t, s, accs[0], creator, nil, creator)
+	tx, _ := buildExtensionTestTx(t, s, accs[0], creator, nil, creator, nil)
 
 	_, err := NewExtensionOptionsDecorator(extensionHubKeeper{storeErr: errors.New("token invalidated")}).
 		AnteHandle(s.ctx, tx, false, nextAnte)

--- a/app/ante/extension_utils.go
+++ b/app/ante/extension_utils.go
@@ -22,7 +22,7 @@ import (
 )
 
 // parseValidateJWS processes a JWS Bearer token by unmarshaling it and verifying its signature.
-func parseValidateJWS(ctx context.Context, resolver did.Resolver, bearerJWS string, skipAuthAccountValidation bool) (antetypes.BearerToken, error) {
+func parseValidateJWS(ctx context.Context, resolver did.Resolver, bearerJWS string, trustedRelay bool) (antetypes.BearerToken, error) {
 	bearerJWS = strings.TrimLeft(bearerJWS, " \n\t\r")
 	if strings.HasPrefix(bearerJWS, "{") {
 		return antetypes.BearerToken{}, fmt.Errorf("JSON serialization is not supported for security reasons")
@@ -39,7 +39,7 @@ func parseValidateJWS(ctx context.Context, resolver did.Resolver, bearerJWS stri
 		return antetypes.BearerToken{}, err
 	}
 
-	err = validateBearerTokenValues(&bearer, skipAuthAccountValidation)
+	err = validateBearerTokenValues(&bearer, trustedRelay)
 	if err != nil {
 		return antetypes.BearerToken{}, err
 	}
@@ -115,7 +115,7 @@ func validateProviderToken(token *antetypes.ProviderToken) error {
 }
 
 // validateBearerTokenValues validates the bearer token values.
-func validateBearerTokenValues(token *antetypes.BearerToken, skipAuthAccountValidation bool) error {
+func validateBearerTokenValues(token *antetypes.BearerToken, trustedRelay bool) error {
 	if strings.HasPrefix(token.IssuerID, "did:") {
 		if err := did.IsValidDID(token.IssuerID); err != nil {
 			return fmt.Errorf("invalid issuer DID: %v", err)
@@ -127,8 +127,12 @@ func validateBearerTokenValues(token *antetypes.BearerToken, skipAuthAccountVali
 		}
 	}
 
-	// Only validate authorized account if bearer auth is not being ignored
-	if !skipAuthAccountValidation {
+	if token.ProviderToken != "" && !trustedRelay {
+		return fmt.Errorf("provider token requires a trusted relay")
+	}
+
+	// Trusted relays bind the worker account through the transaction fee grant.
+	if !trustedRelay {
 		if err := types.IsValidSourceHubAddr(token.AuthorizedAccount); err != nil {
 			return fmt.Errorf("invalid authorized account: %v", err)
 		}
@@ -142,8 +146,8 @@ func validateBearerTokenValues(token *antetypes.BearerToken, skipAuthAccountVali
 }
 
 // validateBearerToken validates the bearer token including timing
-func validateBearerToken(token *antetypes.BearerToken, currentTime *time.Time, skipAuthAccountValidation bool) error {
-	err := validateBearerTokenValues(token, skipAuthAccountValidation)
+func validateBearerToken(token *antetypes.BearerToken, currentTime *time.Time, trustedRelay bool) error {
+	err := validateBearerTokenValues(token, trustedRelay)
 	if err != nil {
 		return err
 	}
@@ -159,16 +163,16 @@ func validateBearerToken(token *antetypes.BearerToken, currentTime *time.Time, s
 
 // validateJWSExtension parses and validates JWS extension option bearer token.
 // Returns the actor DID (from provider token if present, otherwise issuer DID) and the authorized account.
-// If skipAuthAccountValidation is true, the authorized account validation is skipped (when ignoreBearerAuth is enabled).
-func validateJWSExtension(ctx context.Context, bearerToken string, currentTime time.Time, skipAuthAccountValidation bool) (string, string, error) {
+// Provider identities are accepted only from a trusted relay.
+func validateJWSExtension(ctx context.Context, bearerToken string, currentTime time.Time, trustedRelay bool) (string, string, error) {
 	resolver := &did.KeyResolver{}
 
-	token, err := parseValidateJWS(ctx, resolver, bearerToken, skipAuthAccountValidation)
+	token, err := parseValidateJWS(ctx, resolver, bearerToken, trustedRelay)
 	if err != nil {
 		return "", "", err
 	}
 
-	err = validateBearerToken(&token, &currentTime, skipAuthAccountValidation)
+	err = validateBearerToken(&token, &currentTime, trustedRelay)
 	if err != nil {
 		return "", "", err
 	}

--- a/testutil/jws.go
+++ b/testutil/jws.go
@@ -39,6 +39,17 @@ func CreateJWSHeader() map[string]any {
 // GenerateSignedJWSWithMatchingDID creates a JWS bearer token with specified authorized account.
 // Returns the JWS string and the DID.
 func GenerateSignedJWSWithMatchingDID(t *testing.T, authorizedAccount string) (string, string) {
+	return GenerateSignedJWSWithProvider(t, authorizedAccount, nil)
+}
+
+// GenerateSignedJWSWithProvider creates a signed bearer token with optional provider identity metadata.
+func GenerateSignedJWSWithProvider(
+	t *testing.T,
+	authorizedAccount string,
+	providerToken *antetypes.ProviderToken,
+) (string, string) {
+	t.Helper()
+
 	// Derive seed from mnemonic
 	mnemonic := "near smoke great nasty alley food crush nurse rubber say danger search employ under gaze today alien eager risk letter drum relief sponsor current"
 	seed, err := hd.Secp256k1.Derive()(mnemonic, "", "m/44'/118'/0'/0/0")
@@ -58,6 +69,11 @@ func GenerateSignedJWSWithMatchingDID(t *testing.T, authorizedAccount string) (s
 
 	// Create bearer token with the matching DID
 	bearerToken := NewBearerTokenNow(userDID, authorizedAccount)
+	if providerToken != nil {
+		providerJSON, err := json.Marshal(providerToken)
+		require.NoError(t, err)
+		bearerToken.ProviderToken = string(providerJSON)
+	}
 	payloadBytes, err := json.Marshal(bearerToken)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
- reject provider identity metadata on direct transactions
- preserve provider-derived actors for authenticated trusted relays
- cover direct rejection and trusted relay acceptance

## Why
SourceHub verifies the bearer signature against its issuer DID, but the embedded provider actor is asserted by the relay. Accepting that field on a direct transaction lets a caller substitute another actor DID. Trusted relays already bind the worker through the configured fee granter and are the boundary responsible for verifying the external identity token.

## Tests
- `go test ./app/ante ./testutil`
- `go test -race ./app/ante ./testutil`