### PR TITLE
fix: reject governance proposals where combined pool fees exceed 100%

### DIFF
--- a/x/tier/keeper/msg_server_test.go
+++ b/x/tier/keeper/msg_server_test.go
@@ -22,3 +22,54 @@ func TestMsgServer(t *testing.T) {
 	require.NotNil(t, ctx)
 	require.NotEmpty(t, k)
 }
+
+func TestUpdateParams(t *testing.T) {
+	k, ms, ctx := setupMsgServer(t)
+	params := k.GetParams(ctx)
+
+	tests := []struct {
+		name      string
+		devFee    int64
+		insFee    int64
+		expErr    bool
+		expErrMsg string
+	}{
+		{
+			name:      "combined fees exceed 100 is rejected",
+			devFee:    60,
+			insFee:    41,
+			expErr:    true,
+			expErrMsg: "invalid params",
+		},
+		{
+			name:   "combined fees equal 100 is accepted",
+			devFee: 60,
+			insFee: 40,
+			expErr: false,
+		},
+		{
+			name:   "default fees are accepted",
+			devFee: params.DeveloperPoolFee,
+			insFee: params.InsurancePoolFee,
+			expErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := params
+			p.DeveloperPoolFee = tt.devFee
+			p.InsurancePoolFee = tt.insFee
+			_, err := ms.UpdateParams(ctx, &types.MsgUpdateParams{
+				Authority: k.GetAuthority(),
+				Params:    p,
+			})
+			if tt.expErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expErrMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/x/tier/keeper/msg_server_test.go
+++ b/x/tier/keeper/msg_server_test.go
@@ -53,6 +53,13 @@ func TestUpdateParams(t *testing.T) {
 			insFee: params.InsurancePoolFee,
 			expErr: false,
 		},
+		{
+			name:      "int64 overflow combined fees are rejected",
+			devFee:    9223372036854775807,
+			insFee:    1,
+			expErr:    true,
+			expErrMsg: "invalid params",
+		},
 	}
 
 	for _, tt := range tests {

--- a/x/tier/types/params.go
+++ b/x/tier/types/params.go
@@ -78,8 +78,10 @@ func (p Params) Validate() error {
 	if err := validateInsurancePoolFee(p.InsurancePoolFee); err != nil {
 		return err
 	}
-	if p.DeveloperPoolFee+p.InsurancePoolFee > 100 {
-		return fmt.Errorf("combined developer pool fee and insurance pool fee must not exceed 100, got %d", p.DeveloperPoolFee+p.InsurancePoolFee)
+	devFee := math.NewInt(p.DeveloperPoolFee)
+	insFee := math.NewInt(p.InsurancePoolFee)
+	if devFee.Add(insFee).GT(math.NewInt(100)) {
+		return fmt.Errorf("combined developer pool fee and insurance pool fee must not exceed 100, got developer: %d, insurance: %d", p.DeveloperPoolFee, p.InsurancePoolFee)
 	}
 	if err := validateInsurancePoolThreshold(p.InsurancePoolThreshold); err != nil {
 		return err

--- a/x/tier/types/params.go
+++ b/x/tier/types/params.go
@@ -78,6 +78,9 @@ func (p Params) Validate() error {
 	if err := validateInsurancePoolFee(p.InsurancePoolFee); err != nil {
 		return err
 	}
+	if p.DeveloperPoolFee+p.InsurancePoolFee > 100 {
+		return fmt.Errorf("combined developer pool fee and insurance pool fee must not exceed 100, got %d", p.DeveloperPoolFee+p.InsurancePoolFee)
+	}
 	if err := validateInsurancePoolThreshold(p.InsurancePoolThreshold); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

This PR fixes a critical chain-halt vulnerability in the `x/tier` module where a governance
proposal setting `DeveloperPoolFee + InsurancePoolFee > 100%` would crash every validator
node simultaneously and permanently halt the network.

---

## Bug

### Root Cause

`Validate()` in `x/tier/types/params.go` validates `DeveloperPoolFee` and `InsurancePoolFee`
independently but never checks their combined sum:

```go
// BEFORE — each fee validated in isolation, combined sum never checked
func (p Params) Validate() error {
    if err := validateDeveloperPoolFee(p.DeveloperPoolFee); err != nil {   
        return err
    }
    if err := validateInsurancePoolFee(p.InsurancePoolFee); err != nil {   
        return err
    }
    // ❌ missing: no check that DeveloperPoolFee + InsurancePoolFee <= 100
}
```

This means a governance proposal setting DeveloperPoolFee=60 and InsurancePoolFee=60
passes validation successfully despite the combined sum being 120%.

### How the Chain Halts

`processRewards` in `x/tier/keeper/rewards.go` computes the burn amount as:

```go
totalAmount        := rewards.AmountOf(appparams.DefaultBondDenom)
amountToDevPool    := totalAmount.MulRaw(params.DeveloperPoolFee).QuoRaw(100)
amountToInsurancePool := totalAmount.MulRaw(params.InsurancePoolFee).QuoRaw(100)
amountToBurn       := totalAmount.Sub(amountToDevPool).Sub(amountToInsurancePool)
```

When the two fees sum to more than 100, amountToBurn is negative. For example,
with totalAmount = 1000, DeveloperPoolFee = 60, InsurancePoolFee = 41:

amountToDevPool       = 1000 × 60 / 100 =  600
amountToInsurancePool = 1000 × 41 / 100 =  410
amountToBurn          = 1000 - 600 - 410 = -10  ← negative

processRewards then passes this negative value to sdk.NewCoin:

burnCoins := sdk.NewCoins(sdk.NewCoin(appparams.DefaultBondDenom, amountToBurn))

That is When sdk.NewCoin panics inside processRewards:

1. The panic unwinds the entire BeginBlocker execution
2. No block is committed, the chain state does not advance
3. Every validator hits the same panic at the same block height because they all have the same params in state
4. No validator can produce a valid block, so no block ever reaches 2/3 consensus
5. The chain stops producing blocks permanently, since every restart re-executes the same BeginBlocker and panics again at the same height.

The key detail is that the bad params are already written to state (the governance proposal passed and was executed). So there is no "healthy" validator,  they all share the same poisoned state. The only recovery is a coordinated emergency upgrade that either patches the panic or overwrites the params before BeginBlocker runs again.

ERR CONSENSUS FAILURE!!! err="negative coin amount: -3" module=consensus
  panic: negative coin amount: -3
    → sdk.NewCoin (coin.go:26)
    → processRewards.func1 (rewards.go:100)
    → BeginBlocker (abci.go:18)

**Attack Vector**

This is exploitable via governance. An attacker (or a mistaken proposal) needs only to:

1. Submit a MsgUpdateParams proposal setting DeveloperPoolFee + InsurancePoolFee > 100
2. Pass the governance vote (requires sufficient voting power)
3. Wait for the next ProcessRewardsInterval block while the tier module has any staked
delegation earning rewards

On networks with low governance participation or concentrated voting power, this is achievable by a single large token holder.

---
Fix

Added a combined-sum check inside Validate() in x/tier/types/params.go:
```
// AFTER — combined sum validated before params are accepted
func (p Params) Validate() error {
    if err := validateDeveloperPoolFee(p.DeveloperPoolFee); err != nil {
        return err
    }
    if err := validateInsurancePoolFee(p.InsurancePoolFee); err != nil {
        return err
    }
    if p.DeveloperPoolFee+p.InsurancePoolFee > 100 {
        return fmt.Errorf(
            "combined developer pool fee and insurance pool fee must not exceed 100, got %d",
            p.DeveloperPoolFee+p.InsurancePoolFee,
        )
    }
    // ... rest of validation
}
```

Validate() is called by the UpdateParams message server handler before SetParams
writes anything to state:

// msg_server.go
```
func (m *msgServer) UpdateParams(ctx context.Context, msg *types.MsgUpdateParams) (*types.MsgUpdateParamsResponse, error) {
    // ...
    err := msg.Params.Validate()   // ← fix intercepts here, proposal execution fails
    if err != nil {
        return nil, err
    }
    err = m.Keeper.SetParams(ctx, msg.Params)
    // ...
}
```

With the fix, a governance proposal carrying DeveloperPoolFee=60 + InsurancePoolFee=60 passes the vote but fails at execution time, Validate() returns an error, SetParams is never called, the bad params are never written to state, and the chain continues running safely with the existing params.

---
**Verification**

The fix was verified end-to-end on a live two-node local network:

Without the fix — both nodes halted at the same block:
Node 1: 1:56PM ERR CONSENSUS FAILURE!!! err="negative coin amount: -3"
Node 2: 1:56PM ERR CONSENSUS FAILURE!!! err="negative coin amount: -3"

Last block both nodes agreed on: height=710

With the fix — governance proposal rejected at execution, chain continues:
developer_pool_fee: 2    ← unchanged (safe default)
insurance_pool_fee: 1    ← unchanged (safe default)

FIX WORKS — bad params were rejected
Current block height: 732  ← chain still producing blocks, no panic in logs

---
**Test**

A unit test in `x/tier/keeper/msg_server_test.go` (`TestUpdateParams`) confirms the validation gap is closed by testing through the `UpdateParams` message handler, the actual governance entry point that calls `Validate()`.

Run with:
go test ./x/tier/keeper/ -run TestUpdateParams -v
